### PR TITLE
Expose the http client factory builder

### DIFF
--- a/src/TrueLayerSdk/ApiClient.cs
+++ b/src/TrueLayerSdk/ApiClient.cs
@@ -147,14 +147,13 @@ namespace TrueLayerSdk
 
             // Logger.Info("{HttpMethod} {Uri}", httpMethod, httpRequest.RequestUri.AbsoluteUri);
             var httpResponse = await _httpClient.SendAsync(httpRequest, cancellationToken);
-            await ValidateResponseAsync(httpResponse);
+            ValidateResponseAsync(httpResponse);
 
             return httpResponse;
         }
         
-        private async Task ValidateResponseAsync(HttpResponseMessage httpResponse)
+        private void ValidateResponseAsync(HttpResponseMessage httpResponse)
         {
-            await Task.CompletedTask;
             if (!httpResponse.IsSuccessStatusCode)
             {
                 httpResponse.Headers.TryGetValues("Tl-Request-Id", out var requestIdHeader);

--- a/test/Sdk.Tests/TrueLayerServiceCollectionExtensionsTests.cs
+++ b/test/Sdk.Tests/TrueLayerServiceCollectionExtensionsTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TrueLayerSdk;
+using TrueLayerSdk.Auth.Models;
+using TrueLayerSdk.Common.Exceptions;
+using Xunit;
+
+namespace TrueLayer.Sdk.Tests
+{
+    public class TrueLayerServiceCollectionExtensionsTests
+    {
+        private readonly TruelayerConfiguration _configuration;
+
+        public TrueLayerServiceCollectionExtensionsTests()
+        {
+            _configuration = new TruelayerConfiguration("client_id", "secret", true);
+        }
+
+        [Fact]
+        public async Task Can_customise_http_client_builder()
+        {
+            var services = new ServiceCollection()       
+                .AddTruelayerSdk(_configuration, builder 
+                    => builder.ConfigurePrimaryHttpMessageHandler(() => new FakeHandler()))
+                .BuildServiceProvider();
+
+            var api = services.GetRequiredService<ITruelayerApi>();
+            await Assert.ThrowsAsync<TruelayerResourceNotFoundException>(async () => await api.Auth.GetPaymentToken(new GetPaymentTokenRequest()));
+        }
+
+        class FakeHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var httpResponse = new HttpResponseMessage(HttpStatusCode.NotFound);  
+                return Task.FromResult(httpResponse);
+            }
+        }
+    }
+}


### PR DESCRIPTION
There's little value in exposing the `HttpClient` builder. It's more likely that the developer will want to configure the http client pipeline which can be done via the `IHttpClientBuilder` interface. I've added an example of how we can use this technique to test the SDK against stubbed responses.