### PR TITLE
Configure build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       - image: mcr.microsoft.com/dotnet/sdk:5.0
 
     steps:
-      - run: apt update && apt install -yq default-jre # required for Sonar
       - checkout
       - run:
           name: Run Cake script

--- a/build.cake
+++ b/build.cake
@@ -281,11 +281,11 @@ Task("Default")
     .IsDependentOn("GenerateReports");
 
 Task("CI")
-    .IsDependentOn("SonarBegin")
+    //.IsDependentOn("SonarBegin")
     .IsDependentOn("Default")
     //.IsDependentOn("BuildDocs")
-    .IsDependentOn("UploadCoverage")
-    .IsDependentOn("SonarEnd");
+    .IsDependentOn("UploadCoverage");
+    //.IsDependentOn("SonarEnd");
 
 Task("Publish")
     .IsDependentOn("CI")


### PR DESCRIPTION
Enables the Cake build script on CircleCI.

I've disabled Sonar and DocFx until we can figure out how to install Java properly.

Closes #16 