### PR TITLE
PUX-858: update hosted payments page links

### DIFF
--- a/src/TrueLayer/Payments/HppLinkBuilder.cs
+++ b/src/TrueLayer/Payments/HppLinkBuilder.cs
@@ -4,8 +4,8 @@ namespace TrueLayer.Payments
 {
     internal sealed class HppLinkBuilder
     {
-        internal const string SandboxUrl = "https://checkout.truelayer-sandbox.com/";
-        internal const string ProdUrl = "https://checkout.truelayer.com/";
+        internal const string SandboxUrl = "https://payment.truelayer-sandbox.com/";
+        internal const string ProdUrl = "https://payment.truelayer.com/";
 
         private readonly Uri _baseUri;
 

--- a/test/TrueLayer.Tests/HppLinkBuilderTests.cs
+++ b/test/TrueLayer.Tests/HppLinkBuilderTests.cs
@@ -10,11 +10,11 @@ namespace TrueLayer.Tests
         [Fact]
         public void Can_generate_hpp_link()
         {
-            var baseUri = new Uri("https://checkout.truelayer-sandbox.com");
+            var baseUri = new Uri("https://payment.truelayer-sandbox.com");
             var builder = new HppLinkBuilder(baseUri);
 
             var link = builder.Build("payment-id", "payment-token", new Uri("https://localhost.com"));
-            link.ShouldBe("https://checkout.truelayer-sandbox.com/payments#payment_id=payment-id&payment_token=payment-token&return_uri=https://localhost.com/");
+            link.ShouldBe("https://payment.truelayer-sandbox.com/payments#payment_id=payment-id&payment_token=payment-token&return_uri=https://localhost.com/");
         }
     }
 }


### PR DESCRIPTION
As part of https://truelayer.atlassian.net/jira/software/projects/PUX/boards/131?selectedIssue=PUX-858 the payments-ux team is updating the domain of hosted payments page.

Going from `checkout.*.*` to `payment.*.*`