### PR TITLE
[ISSUE-131] Add `preselected` Provider filter for `Create-Payment` endpoint

### DIFF
--- a/examples/MvcExample/MvcExample.csproj
+++ b/examples/MvcExample/MvcExample.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\..\src\TrueLayer\TrueLayer.csproj" />
     </ItemGroup>
 
     <ItemGroup Label="Output Files">
-        <Content Include="ec512-private-key.pem" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="ec512-private-key.pem" CopyToOutputDirectory="Always" />
     </ItemGroup>
 
 </Project>

--- a/src/TrueLayer/Payments/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payments/Model/Beneficiary.cs
@@ -4,7 +4,7 @@ using static TrueLayer.Payments.Model.AccountIdentifier;
 
 namespace TrueLayer.Payments.Model
 {
-    using AccountIdentifierUnion = OneOf<SortCodeAccountNumber>;
+    using AccountIdentifierUnion = OneOf<SortCodeAccountNumber, Iban>;
 
     public static class Beneficiary
     {

--- a/src/TrueLayer/Payments/Model/PaymentMethod.cs
+++ b/src/TrueLayer/Payments/Model/PaymentMethod.cs
@@ -5,7 +5,7 @@ using TrueLayer.Serialization;
 
 namespace TrueLayer.Payments.Model
 {
-    using ProviderUnion = OneOf<UserSelected>;
+    using ProviderUnion = OneOf<UserSelected, Preselected>;
     using BeneficiaryUnion = OneOf<MerchantAccount, ExternalAccount>;
 
     /// <summary>

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -8,7 +8,7 @@ namespace TrueLayer.Payments.Model
     public static class Provider
     {
         /// <summary>
-        /// Represents provider options for 'submit provider selection' action
+        /// Represents provider options that indicates that the provider is to be selected from a collection
         /// </summary>
         [JsonDiscriminator("user_selected")]
         public record UserSelected : IDiscriminated
@@ -22,6 +22,40 @@ namespace TrueLayer.Payments.Model
             /// Gets or sets the filter used to determine the banks that should be displayed on the bank selection screen
             /// </summary>
             public ProviderFilter? Filter { get; init; }
+        }
+
+        /// <summary>
+        /// Represents provider options that indicates that the provider for this payment is preselected
+        /// </summary>
+        [JsonDiscriminator("preselected")]
+        public record Preselected : IDiscriminated
+        {
+            public Preselected(string providerId, string schemeId, RemitterAccount remitter)
+            {
+                ProviderId = providerId.NotNull(nameof(providerId));
+                SchemeId = schemeId.NotNull(nameof(schemeId));
+                Remitter = remitter.NotNull(nameof(remitter));
+            }
+
+            /// <summary>
+            /// Gets the provider type
+            /// </summary>
+            public string Type => "preselected";
+
+            /// <summary>
+            /// Gets the provider Id the PSU will use for this payment
+            /// </summary>
+            public string ProviderId { get; }
+
+            /// <summary>
+            /// Gets the id of the scheme to make the payment over
+            /// </summary>
+            public string SchemeId { get; }
+
+            /// <summary>
+            /// Gets the account details for the remitter
+            /// </summary>
+            public RemitterAccount Remitter { get; }
         }
     }
 }

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -30,11 +30,10 @@ namespace TrueLayer.Payments.Model
         [JsonDiscriminator("preselected")]
         public record Preselected : IDiscriminated
         {
-            public Preselected(string providerId, string schemeId, RemitterAccount remitter)
+            public Preselected(string providerId, string schemeId)
             {
                 ProviderId = providerId.NotNull(nameof(providerId));
                 SchemeId = schemeId.NotNull(nameof(schemeId));
-                Remitter = remitter.NotNull(nameof(remitter));
             }
 
             /// <summary>
@@ -53,9 +52,9 @@ namespace TrueLayer.Payments.Model
             public string SchemeId { get; }
 
             /// <summary>
-            /// Gets the account details for the remitter
+            /// Gets or sets the account details for the remitter
             /// </summary>
-            public RemitterAccount Remitter { get; }
+            public RemitterAccount? Remitter { get; init; }
         }
     }
 }

--- a/src/TrueLayer/Payments/Model/RemitterAccount.cs
+++ b/src/TrueLayer/Payments/Model/RemitterAccount.cs
@@ -1,0 +1,15 @@
+using OneOf;
+
+namespace TrueLayer.Payments.Model
+{
+    using AccountIdentifierUnion = OneOf<
+        AccountIdentifier.SortCodeAccountNumber,
+        AccountIdentifier.Iban>;
+
+    /// <summary>
+    /// Represent a remitter account
+    /// </summary>
+    /// <param name="AccountHolderName">The name of the remitter account holder</param>
+    /// <param name="AccountIdentifier">A unique account identifier for the remitter account</param>
+    public record RemitterAccount(string AccountHolderName, AccountIdentifierUnion AccountIdentifier);
+}

--- a/src/TrueLayer/TrueLayer.csproj
+++ b/src/TrueLayer/TrueLayer.csproj
@@ -12,11 +12,11 @@
     <RepositoryUrl>https://github.com/TrueLayer/truelayer-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[5.0,6.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[5.0,6.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,6.0)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="[5.0,6.0)" />
-    <PackageReference Include="jose-jwt" Version="[3.2,4.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="jose-jwt" Version="3.2.0" />
     <PackageReference Include="OneOf" Version="3.0.201" />
 </ItemGroup>
 <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -101,18 +101,33 @@ namespace TrueLayer.AcceptanceTests
             };
             yield return new object[]
             {
-                CreateTestPaymentRequest(new Provider.Preselected(
-                    "mock-payments-gb-redirect",
-                    "faster_payments_service",
-                    new RemitterAccount("John Doe", new AccountIdentifier.SortCodeAccountNumber("123456", "12345678"))),
+                CreateTestPaymentRequest(
+                    new Provider.Preselected("mock-payments-gb-redirect", "faster_payments_service")
+                    {
+                        Remitter = new RemitterAccount("John Doe", new AccountIdentifier.SortCodeAccountNumber("123456", "12345678")),
+                    },
                     sortCodeAccountNumber),
             };
             yield return new object[]
             {
-                CreateTestPaymentRequest(new Provider.Preselected(
-                    "mock-payments-gb-redirect",
-                    "faster_payments_service",
-                    new RemitterAccount("John Doe", new AccountIdentifier.Iban("FR1420041010050500013M02606"))),
+                CreateTestPaymentRequest(
+                    new Provider.Preselected("mock-payments-gb-redirect", "faster_payments_service")
+                    {
+                        Remitter = new RemitterAccount("John Doe", new AccountIdentifier.Iban("FR1420041010050500013M02606")),
+                    },
+                    new AccountIdentifier.Iban("IT60X0542811101000000123456"),
+                    Currencies.EUR),
+            };
+            yield return new object[]
+            {
+                CreateTestPaymentRequest(
+                    new Provider.Preselected("mock-payments-gb-redirect", "faster_payments_service"),
+                    sortCodeAccountNumber),
+            };
+            yield return new object[]
+            {
+                CreateTestPaymentRequest(
+                    new Provider.Preselected("mock-payments-gb-redirect", "faster_payments_service"),
                     new AccountIdentifier.Iban("IT60X0542811101000000123456"),
                     Currencies.EUR),
             };

--- a/test/TrueLayer.AcceptanceTests/TrueLayer.AcceptanceTests.csproj
+++ b/test/TrueLayer.AcceptanceTests/TrueLayer.AcceptanceTests.csproj
@@ -27,8 +27,7 @@
       <ProjectReference Include="..\..\src\TrueLayer\TrueLayer.csproj" />
     </ItemGroup>
     <ItemGroup Label="Output Files">
-      <None Update="appsettings.*" CopyToOutputDirectory="PreserveNewest" />
-      <None Update="*.pem" CopyToOutputDirectory="PreserveNewest" />
+      <None Update="appsettings.*" CopyToOutputDirectory="Always" />
+      <None Update="*.pem" CopyToOutputDirectory="Always" />
     </ItemGroup>
   </Project>
-  

--- a/test/TrueLayer.AcceptanceTests/appsettings.json
+++ b/test/TrueLayer.AcceptanceTests/appsettings.json
@@ -10,7 +10,7 @@
       "SigningKey": {
         "KeyId": "your-key-id"
       },
-      "Uri": "https://test-pay-api.truelayer-sandbox.com/"
+      "Uri": "https://api.truelayer-sandbox.com/"
     }
   }
 }


### PR DESCRIPTION
This PR is implementi the `PRESELECTED` provider filter for the `Create-Payment` endpoint as described in this [documentation](https://docs.truelayer.com/reference/create-payment).

Closes #131 