### PR TITLE
[ISSUE-133] Return provider data from user selected filter

### DIFF
--- a/examples/MvcExample/Models/DonateModel.cs
+++ b/examples/MvcExample/Models/DonateModel.cs
@@ -14,5 +14,7 @@ namespace MvcExample.Models
         [Required(ErrorMessage = "Your email is required")]
         [EmailAddress(ErrorMessage = "A valid email address is required")]
         public string Email { get; set; }
+
+        public bool UserPreSelectedFilter { get; set; }
     }
 }

--- a/examples/MvcExample/Views/Home/Failed.cshtml
+++ b/examples/MvcExample/Views/Home/Failed.cshtml
@@ -9,4 +9,10 @@
   <div class="alert alert-danger" role="alert">
     @ViewData["Status"]
   </div>
+  <br />
+  <div class="alert alert-info" role="alert">
+    <label>Provider selected:</label>&nbsp;@ViewData["ProviderId"]
+    <br />
+    <label>Scheme Id: </label>&nbsp;@ViewData["SchemeId"]
+  </div>
 </div>

--- a/examples/MvcExample/Views/Home/Index.cshtml
+++ b/examples/MvcExample/Views/Home/Index.cshtml
@@ -21,6 +21,12 @@
       </div>
     </div>
     <div class="form-row">
+      <div class="form-group col-md-12">
+        <label asp-for="UserPreSelectedFilter">Use preselected filter (mock-uk-bank) </label>
+        <input type="checkbox" asp-for="UserPreSelectedFilter">
+      </div>
+    </div>
+    <div class="form-row">
       <div class="input-group mb-3 col-md-12">
         <div class="input-group-prepend">
           <span class="input-group-text">GBP</span>

--- a/examples/MvcExample/Views/Home/Pending.cshtml
+++ b/examples/MvcExample/Views/Home/Pending.cshtml
@@ -10,4 +10,10 @@
   <div class="alert alert-info" role="alert">
     @ViewData["Status"]
   </div>
+  <br/>
+  <div class="alert alert-info" role="alert">
+    <label>Provider selected:</label>&nbsp;@ViewData["ProviderId"]
+    <br />
+    <label>Scheme Id:</label>&nbsp;@ViewData["SchemeId"]
+  </div>
 </div>

--- a/examples/MvcExample/Views/Home/Success.cshtml
+++ b/examples/MvcExample/Views/Home/Success.cshtml
@@ -10,4 +10,10 @@
   <div class="alert alert-success" role="alert">
     @ViewData["Status"]
   </div>
+  <br />
+  <div class="alert alert-info" role="alert">
+    <label>Provider selected:</label>&nbsp;@ViewData["ProviderId"]
+    <br />
+    <label>Scheme Id:</label>&nbsp;@ViewData["SchemeId"]
+  </div>
 </div>

--- a/src/TrueLayer/Extensions/UriExtensions.cs
+++ b/src/TrueLayer/Extensions/UriExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Text.Json;
+using TrueLayer.Serialization;
 
 namespace TrueLayer.Extensions
 {
@@ -11,5 +13,8 @@ namespace TrueLayer.Extensions
                 .Concat(segments.Select(s => s.Trim('/'))));
             return new Uri(newUri);
         }
+
+        public static string ToJson<T>(this ApiResponse<T> response)
+            => JsonSerializer.Serialize(response, SerializerOptions.Default);
     }
 }

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -22,6 +22,18 @@ namespace TrueLayer.Payments.Model
             /// Gets or sets the filter used to determine the banks that should be displayed on the bank selection screen
             /// </summary>
             public ProviderFilter? Filter { get; init; }
+
+            /// <summary>
+            /// Gets the provider Id the PSU will selected for this payment
+            /// The field is populated only when a <see cref="GetPaymentResponse"/> is returned
+            /// </summary>
+            public string? ProviderId { get; init; }
+
+            /// <summary>
+            /// Gets the id of the scheme associated to the selected provider that was used to make the payment over.
+            /// The field is populated only when a <see cref="GetPaymentResponse"/> is returned
+            /// </summary>
+            public string? SchemeId { get; init; }
         }
 
         /// <summary>

--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -54,11 +54,11 @@ namespace TrueLayer.Payouts.Model
         [JsonDiscriminator("external_account")]
         public sealed record ExternalAccount : IDiscriminated
         {
-            public ExternalAccount(string accountHolderName, string reference, AccountIdentifierUnion schemeIdentifier)
+            public ExternalAccount(string accountHolderName, string reference, AccountIdentifierUnion accountIdentifier)
             {
                 AccountHolderName = accountHolderName.NotNullOrWhiteSpace(nameof(accountHolderName));
                 Reference = reference.NotNullOrWhiteSpace(nameof(reference));
-                AccountIdentifier = schemeIdentifier;
+                AccountIdentifier = accountIdentifier;
             }
 
             /// <summary>

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -63,22 +63,24 @@ namespace TrueLayer.AcceptanceTests
             payment.Id.ShouldNotBeNullOrWhiteSpace();
             payment.CreatedAt.ShouldNotBe(default);
             payment.PaymentMethod.AsT0.ShouldNotBeNull();
-            if (payment.PaymentMethod.AsT0.ProviderSelection.IsT0)
-            {
-                Provider.UserSelected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT0;
-                Provider.UserSelected providerSelectionResponse = payment.PaymentMethod.AsT0.ProviderSelection.AsT0;
-                providerSelectionResponse.Filter.ShouldBeEquivalentTo(providerSelectionReq.Filter);
-                // Provider selection hasn't happened yet
-                providerSelectionResponse.ProviderId.ShouldBeNullOrEmpty();
-                providerSelectionResponse.SchemeId.ShouldBeNullOrEmpty();
-            }
-            else
-            {
-                Provider.Preselected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT1;
-                Provider.Preselected providerSelectionResponse = payment.PaymentMethod.AsT0.ProviderSelection.AsT1;
-                providerSelectionResponse.ProviderId.ShouldBe(providerSelectionReq.ProviderId);
-                providerSelectionResponse.SchemeId.ShouldBe(providerSelectionReq.SchemeId);
-            }
+
+            payment.PaymentMethod.Switch(
+                bankTransfer => bankTransfer.ProviderSelection.Switch(
+                    userSelected =>
+                    {
+                        Provider.UserSelected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT0;
+                        userSelected.Filter.ShouldBeEquivalentTo(providerSelectionReq.Filter);
+                        // Provider selection hasn't happened yet
+                        userSelected.ProviderId.ShouldBeNullOrEmpty();
+                        userSelected.SchemeId.ShouldBeNullOrEmpty();
+                    },
+                    preselected =>
+                    {
+                        Provider.Preselected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT1;
+                        preselected.ProviderId.ShouldBe(providerSelectionReq.ProviderId);
+                        preselected.SchemeId.ShouldBe(providerSelectionReq.SchemeId);
+                    })
+            );
 
             payment.PaymentMethod.AsT0.Beneficiary.TryPickT1(out var externalAccount, out _).ShouldBeTrue();
             payment.User.ShouldNotBeNull();

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -63,6 +63,23 @@ namespace TrueLayer.AcceptanceTests
             payment.Id.ShouldNotBeNullOrWhiteSpace();
             payment.CreatedAt.ShouldNotBe(default);
             payment.PaymentMethod.AsT0.ShouldNotBeNull();
+            if (payment.PaymentMethod.AsT0.ProviderSelection.IsT0)
+            {
+                Provider.UserSelected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT0;
+                Provider.UserSelected providerSelectionResponse = payment.PaymentMethod.AsT0.ProviderSelection.AsT0;
+                providerSelectionResponse.Filter.ShouldBeEquivalentTo(providerSelectionReq.Filter);
+                // Provider selection hasn't happened yet
+                providerSelectionResponse.ProviderId.ShouldBeNullOrEmpty();
+                providerSelectionResponse.SchemeId.ShouldBeNullOrEmpty();
+            }
+            else
+            {
+                Provider.Preselected providerSelectionReq = paymentRequest.PaymentMethod.AsT0.ProviderSelection.AsT1;
+                Provider.Preselected providerSelectionResponse = payment.PaymentMethod.AsT0.ProviderSelection.AsT1;
+                providerSelectionResponse.ProviderId.ShouldBe(providerSelectionReq.ProviderId);
+                providerSelectionResponse.SchemeId.ShouldBe(providerSelectionReq.SchemeId);
+            }
+
             payment.PaymentMethod.AsT0.Beneficiary.TryPickT1(out var externalAccount, out _).ShouldBeTrue();
             payment.User.ShouldNotBeNull();
             payment.User.Id.ShouldBe(response.Data.User.Id);


### PR DESCRIPTION
Closes #133 

Extra:
- Added an option to specify whether to use a preselected filter or a user-selected one in the demo page
- Fixed typo in `Payout.Beneficiary.ExternalAccount`
- Provided `ApiRepsonse<T>.ToJson<T>()` extension method to get the API response as `json` using the internal `JsonSerialiser`