### PR TITLE
[SPAIN-367] Enable payment_source for payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,7 @@ This will serve the docs on http://localhost:8080.
 
 Contributions are always welcome!
 
-See [contributing](contributing.md) for ways to get started.
-
 Please adhere to this project's [code of conduct](CODE_OF_CONDUCT.md).
-
 
 ## License
 

--- a/examples/MvcExample/Controllers/PayoutController.cs
+++ b/examples/MvcExample/Controllers/PayoutController.cs
@@ -111,6 +111,7 @@ namespace MvcExample.Controllers
                 authorizing => Pending(authorizing),
                 authorized => Success(authorized),
                 successful => Success(successful),
+                executed => Success(executed),
                 failed => Failed(failed.Status)
             );
         }

--- a/src/TrueLayer/Payouts/IPayoutsApi.cs
+++ b/src/TrueLayer/Payouts/IPayoutsApi.cs
@@ -10,6 +10,7 @@ namespace TrueLayer.Payouts
         Pending,
         Authorized,
         Successful,
+        Executed,
         Failed
     >;
 

--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -15,29 +15,37 @@ namespace TrueLayer.Payouts.Model
         public sealed record PaymentSource : IDiscriminated
         {
             /// <summary>
-            /// Creates a new <see cref="PaymentSource"/>
+            /// Creates a new <see cref="PaymentSource"/>.
             /// </summary>
-            /// <param name="id">The TrueLayer merchant account identifier</param>
-            public PaymentSource(string id)
+            /// <param name="paymentSourceId">ID of the external account which has become a payment source.</param>
+            /// <param name="userId">ID of the owning user of the external account.</param>
+            /// <param name="reference">A reference for the payout.</param>
+            public PaymentSource(string paymentSourceId, string userId, string reference)
             {
-                Id = id.NotNullOrWhiteSpace(nameof(id));
+                PaymentSourceId = paymentSourceId.NotNullOrWhiteSpace(nameof(paymentSourceId));
+                UserId = userId.NotNullOrWhiteSpace(nameof(userId));
+                Reference = reference.NotNullOrWhiteSpace(nameof(reference));
             }
 
             /// <summary>
             /// Gets the type of beneficiary
             /// </summary>
-            public string Type => "merchant_account";
+            public string Type => "payment_source";
 
             /// <summary>
-            /// Gets the TrueLayer merchant account identifier
+            /// ID of the external account which has become a payment source.
             /// </summary>
-            public string Id { get; }
+            public string PaymentSourceId { get; }
 
             /// <summary>
-            /// The name of the beneficiary.
-            /// If unspecified, the API will use the account owner name associated to the selected merchant account.
+            /// ID of the owning user of the external account.
             /// </summary>
-            public string? Name { get; init; }
+            public string UserId { get; }
+
+            /// <summary>
+            /// A reference for the payout.
+            /// </summary>
+            public string Reference { get; }
         }
 
         /// <summary>

--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -43,7 +43,7 @@ namespace TrueLayer.Payouts.Model
             public string UserId { get; }
 
             /// <summary>
-            /// A reference for the payout.
+            /// Gets a reference for the payout.
             /// </summary>
             public string Reference { get; }
         }

--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -33,7 +33,7 @@ namespace TrueLayer.Payouts.Model
             public string Type => "payment_source";
 
             /// <summary>
-            /// ID of the external account which has become a payment source.
+            /// Gets the ID of the external account which has become a payment source
             /// </summary>
             public string PaymentSourceId { get; }
 

--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -38,7 +38,7 @@ namespace TrueLayer.Payouts.Model
             public string PaymentSourceId { get; }
 
             /// <summary>
-            /// ID of the owning user of the external account.
+            /// Gets the ID of the owning user of the external account.
             /// </summary>
             public string UserId { get; }
 

--- a/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
+++ b/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
@@ -70,6 +70,15 @@ namespace TrueLayer.Payouts.Model
         public record Successful(DateTime SucceededAt) : PayoutDetails;
 
         /// <summary>
+        /// Represents a payout that has been executed.
+        /// For open loop payouts this state is terminate. For closed-loop payouts, wait for Settled.
+        /// </summary>
+        /// <param name="ExecutedAt">The date and time the payout got executed</param>
+        /// <returns></returns>
+        [JsonDiscriminator("executed")]
+        public record Executed(DateTime ExecutedAt) : PayoutDetails;
+
+        /// <summary>
         /// Represents an authorized payout that failed to complete. This is a terminate state.
         /// </summary>
         /// <param name="FailedAt">The date and time the payout failed</param>

--- a/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
+++ b/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
@@ -71,7 +71,6 @@ namespace TrueLayer.Payouts.Model
 
         /// <summary>
         /// Represents a payout that has been executed.
-        /// For open loop payouts this state is terminate. For closed-loop payouts, wait for Settled.
         /// </summary>
         /// <param name="ExecutedAt">The date and time the payout got executed</param>
         /// <returns></returns>

--- a/src/TrueLayer/Payouts/PayoutsApi.cs
+++ b/src/TrueLayer/Payouts/PayoutsApi.cs
@@ -13,6 +13,7 @@ namespace TrueLayer.Payouts
         Pending,
         Authorized,
         Successful,
+        Executed,
         Failed
     >;
 

--- a/test/TrueLayer.Tests/Payouts/PayoutsApiTests.cs
+++ b/test/TrueLayer.Tests/Payouts/PayoutsApiTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using OneOf;
 using Moq;
 using Shouldly;
 using TrueLayer.Auth;
@@ -34,8 +36,9 @@ namespace TrueLayer.Tests.Payouts
             };
         }
 
-        [Fact]
-        public async Task CreatePayout_Returns_Empty_Response_With_Http_Status_Code_On_Auth_Failure()
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task CreatePayout_Returns_Empty_Response_With_Http_Status_Code_On_Auth_Failure(CreatePayoutRequest createPayoutRequest)
         {
             // Arrange
             var authApiMock = new Mock<IAuthApi>();
@@ -45,7 +48,7 @@ namespace TrueLayer.Tests.Payouts
             var sut = new PayoutsApi(Mock.Of<IApiClient>(), authApiMock.Object, _trueLayerOptions);
 
             // Act
-            var actual = await sut.CreatePayout(CreatePayoutRequest(), "indepotency-key", CancellationToken.None);
+            var actual = await sut.CreatePayout(createPayoutRequest, "indepotency-key", CancellationToken.None);
 
             //Assert
             actual.ShouldNotBeNull();
@@ -74,16 +77,40 @@ namespace TrueLayer.Tests.Payouts
             actual.TraceId.ShouldBe("trace-id");
         }
 
-        private static CreatePayoutRequest CreatePayoutRequest()
-            => new CreatePayoutRequest(
-                "merchant-account-id",
-                100,
-                Currencies.GBP,
-                new Beneficiary.ExternalAccount(
+        private static CreatePayoutRequest CreatePayoutRequest(bool paymentSource = false)
+        {
+            OneOf<Beneficiary.PaymentSource, Beneficiary.ExternalAccount> beneficiary;
+
+            if (paymentSource)
+            {
+                beneficiary = new Beneficiary.PaymentSource(
+                    "payment-source-id",
+                    "user-id",
+                    "truelayer-dotnet"
+                );
+            }
+            else
+            {
+                beneficiary = new Beneficiary.ExternalAccount(
                     "Ms. Lucky",
                     "truelayer-dotnet",
                     new AccountIdentifier.Iban("GB33BUKB20201555555555")
-                )
+                );
+            }
+
+            return new CreatePayoutRequest(
+                "merchant-account-id",
+                100,
+                Currencies.GBP,
+                beneficiary
             );
+        }
+
+        public static IEnumerable<object[]> TestData =>
+            new List<object[]>
+            {
+                new object[] { CreatePayoutRequest() },
+                new object[] { CreatePayoutRequest(true) },
+            };
     }
 }


### PR DESCRIPTION
With this PR, users will be able to send out payouts using the `payment_source` type. This will facilitate payouts operations when a user has alsready made a payment towards your `merchant_account`.

More info can be found on our official [documentation](https://docs.truelayer.com/docs/when-to-use-payouts#payout-to-an-user).

Closes #134