### PR TITLE
[ISSUE-141] Remove payouts successful status (no longer used)

### DIFF
--- a/examples/MvcExample/Controllers/PayoutController.cs
+++ b/examples/MvcExample/Controllers/PayoutController.cs
@@ -110,7 +110,6 @@ namespace MvcExample.Controllers
             return apiResponse.Data.Match(
                 authorizing => Pending(authorizing),
                 authorized => Success(authorized),
-                successful => Success(successful),
                 executed => Success(executed),
                 failed => Failed(failed.Status)
             );

--- a/src/TrueLayer/Payouts/IPayoutsApi.cs
+++ b/src/TrueLayer/Payouts/IPayoutsApi.cs
@@ -9,7 +9,6 @@ namespace TrueLayer.Payouts
     using GetPayoutUnion = OneOf<
         Pending,
         Authorized,
-        Successful,
         Executed,
         Failed
     >;

--- a/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
+++ b/src/TrueLayer/Payouts/Model/GetPayoutsResponse.cs
@@ -61,15 +61,6 @@ namespace TrueLayer.Payouts.Model
         public record Authorized : PayoutDetails;
 
         /// <summary>
-        /// Represents a payout that has succeeded
-        /// For open loop payouts this state is terminate. For closed-loop payouts, wait for Settled.
-        /// </summary>
-        /// <param name="SucceededAt">The date and time the payout succeeded</param>
-        /// <returns></returns>
-        [JsonDiscriminator("successful")]
-        public record Successful(DateTime SucceededAt) : PayoutDetails;
-
-        /// <summary>
         /// Represents a payout that has been executed.
         /// </summary>
         /// <param name="ExecutedAt">The date and time the payout got executed</param>

--- a/src/TrueLayer/Payouts/PayoutsApi.cs
+++ b/src/TrueLayer/Payouts/PayoutsApi.cs
@@ -12,7 +12,6 @@ namespace TrueLayer.Payouts
     using GetPayoutUnion = OneOf<
         Pending,
         Authorized,
-        Successful,
         Executed,
         Failed
     >;


### PR DESCRIPTION
There is no longer a `successful` status for payouts, this has been replaced with `executed` (which is already implemented in this SDK from a previous PR).