### PR TITLE
[ISSUE-140] Add business account payout beneficiary

### DIFF
--- a/src/TrueLayer/Payouts/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payouts/Model/Beneficiary.cs
@@ -81,5 +81,30 @@ namespace TrueLayer.Payouts.Model
             /// </summary>
             public AccountIdentifierUnion AccountIdentifier { get; }
         }
+
+        /// <summary>
+        /// Represent's a client's preconfigured business account.
+        /// </summary>
+        public sealed record BusinessAccount : IDiscriminated
+        {
+            /// <summary>
+            /// Creates a new <see cref="BusinessAccount"/>.
+            /// </summary>
+            /// <param name="reference">A reference for the payout.</param>
+            public BusinessAccount(string reference)
+            {
+                Reference = reference.NotNullOrWhiteSpace(nameof(reference));
+            }
+
+            /// <summary>
+            /// Gets the type of beneficiary
+            /// </summary>
+            public string Type => "business_account";
+
+            /// <summary>
+            /// Gets a reference for the payout.
+            /// </summary>
+            public string Reference { get; }
+        }
     }
 }

--- a/src/TrueLayer/Payouts/Model/CreatePayoutRequest.cs
+++ b/src/TrueLayer/Payouts/Model/CreatePayoutRequest.cs
@@ -3,7 +3,7 @@ using static TrueLayer.Payouts.Model.Beneficiary;
 
 namespace TrueLayer.Payouts.Model
 {
-    using BeneficiaryUnion = OneOf<PaymentSource, ExternalAccount>;
+    using BeneficiaryUnion = OneOf<PaymentSource, ExternalAccount, BusinessAccount>;
 
     /// <summary>
     /// Represents a request for payout


### PR DESCRIPTION
Payouts has exposed a new beneficiary type, `business_account`. This allows payouts to a client's preconfigured business account IBAN. This PR adds support for this beneficiary type.