### PR TITLE
[PAYG-1150][PAYG-1168] Add status to create payment response

### DIFF
--- a/src/TrueLayer/Payments/IPaymentsApi.cs
+++ b/src/TrueLayer/Payments/IPaymentsApi.cs
@@ -3,17 +3,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using OneOf;
 using TrueLayer.Payments.Model;
-using static TrueLayer.Payments.Model.GetPaymentResponse;
 
 namespace TrueLayer.Payments
 {
+    using CreatePaymentUnion = OneOf<
+        CreatePaymentResponse.AuthorizationRequired,
+        CreatePaymentResponse.Authorized,
+        CreatePaymentResponse.Failed
+    >;
+
     using GetPaymentUnion = OneOf<
-        AuthorizationRequired,
-        Authorizing,
-        Authorized,
-        Executed,
-        Settled,
-        Failed
+        GetPaymentResponse.AuthorizationRequired,
+        GetPaymentResponse.Authorizing,
+        GetPaymentResponse.Authorized,
+        GetPaymentResponse.Executed,
+        GetPaymentResponse.Settled,
+        GetPaymentResponse.Failed
     >;
 
     /// <summary>
@@ -31,7 +36,7 @@ namespace TrueLayer.Payments
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
         /// <returns>An API response that includes details of the created payment if successful, otherwise problem details</returns>
-        Task<ApiResponse<CreatePaymentResponse>> CreatePayment(
+        Task<ApiResponse<CreatePaymentUnion>> CreatePayment(
             CreatePaymentRequest paymentRequest, string idempotencyKey, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
@@ -1,10 +1,57 @@
+using TrueLayer.Serialization;
+
 namespace TrueLayer.Payments.Model
 {
     /// <summary>
-    /// Create Payment Response type
+    /// Create Payment Response Types
     /// </summary>
-    /// <param name="Id">The unique identifier of the payment</param>
-    /// <param name="ResourceToken">The token used to complete the payment via a front-end channel</param>
-    /// <param name="User">The end user details</param>
-    public record CreatePaymentResponse(string Id, string ResourceToken, PaymentUserResponse User);
+    public static class CreatePaymentResponse
+    {
+        /// <summary>
+        /// Base class containing common properties for all payment states
+        /// </summary>
+        /// <value></value>
+        public record PaymentDetails
+        {
+            /// <summary>
+            /// Gets the unique identifier of the payment
+            /// </summary>
+            public string Id { get; init; } = null!;
+
+            /// <summary>
+            /// Gets the token used to complete the payment via a front-end channel
+            /// </summary>
+            public string ResourceToken { get; init; } = null!;
+
+            /// <summary>
+            /// Gets the end user details
+            /// </summary>
+            public PaymentUserResponse User { get; init; } = null!;
+
+            /// <summary>
+            /// Gets the status of the payment
+            /// </summary>
+            public string Status { get; init; } = null!;
+        }
+
+        /// <summary>
+        /// Represents a payment that requires further authorization
+        /// </summary>
+        [JsonDiscriminator("authorization_required")]
+        public record AuthorizationRequired : PaymentDetails;
+
+        /// <summary>
+        /// Represents a payment that has been authorized by the end user
+        /// </summary>
+        [JsonDiscriminator("authorized")]
+        public record Authorized : PaymentDetails;
+
+        /// <summary>
+        /// Represents a payment that failed to complete. This is a terminal state.
+        /// </summary>
+        /// <param name="FailureStage">The status the payment was in when it failed</param>
+        /// <param name="FailureReason">The reason for failure</param>
+        [JsonDiscriminator("failed")]
+        public record Failed(string FailureStage, string FailureReason) : PaymentDetails;
+    }
 }

--- a/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
@@ -77,7 +77,7 @@ namespace TrueLayer.Payments.Model
 
         /// <summary>
         /// Represents a payment that has been executed
-        /// For open loop payments this state is terminate. For closed-loop payments, wait for Settled.
+        /// For open loop payments this state is terminal. For closed-loop payments, wait for Settled.
         /// </summary>
         /// <param name="ExecutedAt">The date and time the payment executed</param>
         /// <returns></returns>
@@ -86,7 +86,7 @@ namespace TrueLayer.Payments.Model
 
         /// <summary>
         /// Represents a payment that has settled
-        /// This is a terminate state for closed-loop payments.
+        /// This is a terminal state for closed-loop payments.
         /// </summary>
         /// <param name="ExecutedAt">The date and time the payment executed</param>
         /// <param name="SettledAt">The date and time the payment was settled</param>
@@ -96,7 +96,7 @@ namespace TrueLayer.Payments.Model
         public record Settled(DateTime ExecutedAt, DateTime SettledAt, PaymentSource PaymentSource) : PaymentDetails;
 
         /// <summary>
-        /// Represents an authorized payment that failed to complete. This is a terminate state.
+        /// Represents a payment that failed to complete. This is a terminal state.
         /// </summary>
         /// <param name="FailedAt">The date and time the payment failed</param>
         /// <param name="FailureStage">The status the payment was in when it failed</param>

--- a/src/TrueLayer/Payments/PaymentsApi.cs
+++ b/src/TrueLayer/Payments/PaymentsApi.cs
@@ -4,17 +4,22 @@ using System.Threading.Tasks;
 using OneOf;
 using TrueLayer.Auth;
 using TrueLayer.Payments.Model;
-using static TrueLayer.Payments.Model.GetPaymentResponse;
 
 namespace TrueLayer.Payments
 {
+    using CreatePaymentUnion = OneOf<
+        CreatePaymentResponse.AuthorizationRequired,
+        CreatePaymentResponse.Authorized,
+        CreatePaymentResponse.Failed
+    >;
+
     using GetPaymentUnion = OneOf<
-        AuthorizationRequired,
-        Authorizing,
-        Authorized,
-        Executed,
-        Settled,
-        Failed
+        GetPaymentResponse.AuthorizationRequired,
+        GetPaymentResponse.Authorizing,
+        GetPaymentResponse.Authorized,
+        GetPaymentResponse.Executed,
+        GetPaymentResponse.Settled,
+        GetPaymentResponse.Failed
     >;
 
     internal class PaymentsApi : IPaymentsApi
@@ -44,7 +49,7 @@ namespace TrueLayer.Payments
         }
 
         /// <inheritdoc />
-        public async Task<ApiResponse<CreatePaymentResponse>> CreatePayment(CreatePaymentRequest paymentRequest, string idempotencyKey, CancellationToken cancellationToken = default)
+        public async Task<ApiResponse<CreatePaymentUnion>> CreatePayment(CreatePaymentRequest paymentRequest, string idempotencyKey, CancellationToken cancellationToken = default)
         {
             paymentRequest.NotNull(nameof(paymentRequest));
             idempotencyKey.NotNullOrWhiteSpace(nameof(idempotencyKey));
@@ -56,7 +61,7 @@ namespace TrueLayer.Payments
                 return new(authResponse.StatusCode, authResponse.TraceId);
             }
 
-            return await _apiClient.PostAsync<CreatePaymentResponse>(
+            return await _apiClient.PostAsync<CreatePaymentUnion>(
                 _baseUri,
                 paymentRequest,
                 idempotencyKey,

--- a/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
+++ b/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
@@ -73,7 +73,7 @@ namespace TrueLayer.AcceptanceTests
                 paymentRequest, idempotencyKey: Guid.NewGuid().ToString());
 
             createPaymentResponse.IsSuccessful.ShouldBeTrue();
-            var createPaymentUser = createPaymentResponse.Data!.User;
+            var createPaymentUser = createPaymentResponse.Data!.AsT0.User;
 
             // Act
             var getPaymentSourcesResponse

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -29,16 +29,15 @@ namespace TrueLayer.AcceptanceTests
                 paymentRequest, idempotencyKey: Guid.NewGuid().ToString());
 
             response.StatusCode.ShouldBe(HttpStatusCode.Created);
-            response.Data.ShouldBeOfType<CreatePaymentResponse>();
-
-            response.Data.ShouldNotBeNull();
-            response.Data.Id.ShouldNotBeNullOrWhiteSpace();
-            response.Data.ResourceToken.ShouldNotBeNullOrWhiteSpace();
-            response.Data.User.ShouldNotBeNull();
-            response.Data.User.Id.ShouldNotBeNullOrWhiteSpace();
+            response.Data.IsT0.ShouldBeTrue();
+            response.Data.AsT0.Id.ShouldNotBeNullOrWhiteSpace();
+            response.Data.AsT0.ResourceToken.ShouldNotBeNullOrWhiteSpace();
+            response.Data.AsT0.User.ShouldNotBeNull();
+            response.Data.AsT0.User.Id.ShouldNotBeNullOrWhiteSpace();
+            response.Data.AsT0.Status.ShouldBe("authorization_required");
 
             string hppUri = _fixture.Client.Payments.CreateHostedPaymentPageLink(
-                response.Data!.Id, response.Data!.ResourceToken, new Uri("https://redirect.mydomain.com"));
+                response.Data.AsT0.Id, response.Data.AsT0.ResourceToken, new Uri("https://redirect.mydomain.com"));
             hppUri.ShouldNotBeNullOrWhiteSpace();
         }
 
@@ -50,9 +49,11 @@ namespace TrueLayer.AcceptanceTests
                 paymentRequest, idempotencyKey: Guid.NewGuid().ToString());
 
             response.IsSuccessful.ShouldBeTrue();
+            response.Data.IsT0.ShouldBeTrue();
+            var authorizationRequiredResponse = response.Data.AsT0;
 
             var getPaymentResponse
-                = await _fixture.Client.Payments.GetPayment(response.Data!.Id);
+                = await _fixture.Client.Payments.GetPayment(authorizationRequiredResponse.Id);
 
             getPaymentResponse.IsSuccessful.ShouldBeTrue();
 
@@ -84,7 +85,7 @@ namespace TrueLayer.AcceptanceTests
 
             payment.PaymentMethod.AsT0.Beneficiary.TryPickT1(out var externalAccount, out _).ShouldBeTrue();
             payment.User.ShouldNotBeNull();
-            payment.User.Id.ShouldBe(response.Data.User.Id);
+            payment.User.Id.ShouldBe(authorizationRequiredResponse.User.Id);
             payment.User.Name.ShouldBe(paymentRequest.User!.Name);
             payment.User.Email.ShouldBe(paymentRequest.User!.Email);
             payment.User.Phone.ShouldBe(paymentRequest.User!.Phone);

--- a/test/TrueLayer.Benchmarks/SerializationBenchmarks.cs
+++ b/test/TrueLayer.Benchmarks/SerializationBenchmarks.cs
@@ -12,29 +12,35 @@ namespace TrueLayer.Benchmarks
     [MemoryDiagnoser]
     public class SerializationBenchmarks
     {
-        static byte[] Json = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(CreatePaymentResponse(), SerializerOptions.Default));
+        private static byte[] Json =
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(CreatePaymentResponse(), SerializerOptions.Default));
 
         [Benchmark(Baseline = true)]
-        public async Task<CreatePaymentResponse?> FromString()
+        public async Task<CreatePaymentResponse.AuthorizationRequired?> FromString()
         {
             using var stream = new MemoryStream(Json);
             using var reader = new StreamReader(stream);
             var json = await reader.ReadToEndAsync();
-            return JsonSerializer.Deserialize<CreatePaymentResponse>(json, SerializerOptions.Default);
+            return JsonSerializer.Deserialize<CreatePaymentResponse.AuthorizationRequired>(json,
+                SerializerOptions.Default);
         }
 
         [Benchmark]
-        public async Task<CreatePaymentResponse?> FromStream()
+        public async Task<CreatePaymentResponse.AuthorizationRequired?> FromStream()
         {
             using var stream = new MemoryStream(Json);
-            return await JsonSerializer.DeserializeAsync<CreatePaymentResponse>(stream, SerializerOptions.Default);
+            return await JsonSerializer.DeserializeAsync<CreatePaymentResponse.AuthorizationRequired>(stream,
+                SerializerOptions.Default);
         }
 
-        private static CreatePaymentResponse CreatePaymentResponse()
-            => new(
-                "b0110edb-7964-4e22-b971-060d6445bb43",
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJtdmNleGFtcGxlLTVlM2EzMCIsImp0aSI6ImIwMTEwZWRiLTc5NjQtNGUyMi1iOTcxLTA2MGQ2NDQ1YmI0MyIsIm5iZiI6MTYzNDkyNDQ1NiwiZXhwIjoxNjM0OTI1MzU2LCJpc3MiOiJodHRwczovL2FwaS50N3IuZGV2IiwiYXVkIjoiaHR0cHM6Ly9hcGkudDdyLmRldiJ9.Zz7Eg9Aas6Q9uOlTji9xnre1Vzdemtrs40W6hKdgw6M",
-                new PaymentUserResponse(Guid.NewGuid().ToString())
-            );
+        private static CreatePaymentResponse.AuthorizationRequired CreatePaymentResponse()
+            => new()
+            {
+                Id = "b0110edb-7964-4e22-b971-060d6445bb43",
+                ResourceToken =
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJtdmNleGFtcGxlLTVlM2EzMCIsImp0aSI6ImIwMTEwZWRiLTc5NjQtNGUyMi1iOTcxLTA2MGQ2NDQ1YmI0MyIsIm5iZiI6MTYzNDkyNDQ1NiwiZXhwIjoxNjM0OTI1MzU2LCJpc3MiOiJodHRwczovL2FwaS50N3IuZGV2IiwiYXVkIjoiaHR0cHM6Ly9hcGkudDdyLmRldiJ9.Zz7Eg9Aas6Q9uOlTji9xnre1Vzdemtrs40W6hKdgw6M",
+                User = new PaymentUserResponse(Guid.NewGuid().ToString()),
+                Status = "authorization_required",
+            };
     }
 }


### PR DESCRIPTION
The create payment response now includes a `status` field to disambiguate the cases where a payment requires authorisation, was created at an already authorised state, or was created but then failed.