### PR TITLE
[EWT-42] Upgrade to `.NET 6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
-      - name: Setup .NET 5.0
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Setup .NET 3.1
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11.0.x
-      - name: Setup .NET 5.0
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Setup .NET 3.1
         uses: actions/setup-dotnet@v1
         with:

--- a/examples/MvcExample/MvcExample.csproj
+++ b/examples/MvcExample/MvcExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/TrueLayer/ApiClient.cs
+++ b/src/TrueLayer/ApiClient.cs
@@ -9,7 +9,7 @@ using System.Net.Mime;
 using TrueLayer.Serialization;
 using System.Text.Json;
 using TrueLayer.Signing;
-#if NET5_0 || NET5_0_OR_GREATER
+#if NET6_0 || NET6_0_OR_GREATER
 using System.Net.Http.Json;
 #endif
 
@@ -117,7 +117,7 @@ namespace TrueLayer
             {
                 try
                 {
-#if NET5_0 || NET5_0_OR_GREATER
+#if NET6_0 || NET6_0_OR_GREATER
                     data = await httpResponse.Content.ReadFromJsonAsync<TData>(SerializerOptions.Default, cancellationToken);
 #else
                     using var contentStream = await httpResponse.Content.ReadAsStreamAsync();
@@ -168,7 +168,7 @@ namespace TrueLayer
                 }
                 else // Otherwise we can serialize directly to stream for .NET 5.0 onwards
                 {
-#if (NET5_0 || NET5_0_OR_GREATER)
+#if (NET6_0 || NET6_0_OR_GREATER)
                     httpContent = JsonContent.Create(request, request.GetType(), options: SerializerOptions.Default);
 #else
                     // for older versions of .NET we'll have to fall back to using StringContent

--- a/src/TrueLayer/ApiResponseOfT.cs
+++ b/src/TrueLayer/ApiResponseOfT.cs
@@ -36,7 +36,7 @@ namespace TrueLayer
         /// Gets whether the API request completed successfully
         /// </summary>
         /// <returns>True if successful, otherwise False</returns>
-#if NET5_0 || NET5_0_OR_GREATER
+#if NET6_0 || NET6_0_OR_GREATER
         [MemberNotNullWhen(true, nameof(Data))]
 #endif
         public override bool IsSuccessful => base.IsSuccessful;

--- a/src/TrueLayer/Serialization/SerializerOptions.cs
+++ b/src/TrueLayer/Serialization/SerializerOptions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace TrueLayer.Serialization
 {
@@ -6,7 +7,7 @@ namespace TrueLayer.Serialization
     {
         public static readonly JsonSerializerOptions Default = new JsonSerializerOptions
         {
-            IgnoreNullValues = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             PropertyNamingPolicy = JsonSnakeCaseNamingPolicy.Instance,
             Converters = { new OneOfJsonConverterFactory() }
         };

--- a/src/TrueLayer/SigningKey.cs
+++ b/src/TrueLayer/SigningKey.cs
@@ -16,7 +16,7 @@ namespace TrueLayer
         {
             _key = new Lazy<ECDsa>(() => CreateECDsaKey(PrivateKey));
         }
-        
+
         /// <summary>
         /// Sets the private key. Should not be shared with anyone outside of your organisation.
         /// </summary>
@@ -30,12 +30,12 @@ namespace TrueLayer
         internal ECDsa Value => _key.Value;
 
         private static ECDsa CreateECDsaKey(string privateKey)
-        {           
+        {
             privateKey.NotNullOrWhiteSpace(nameof(privateKey));
-            
+
             var key = ECDsa.Create();
 
-#if (NET5_0 || NET5_0_OR_GREATER)
+#if (NET6_0 || NET6_0_OR_GREATER)
             // Ref https://www.scottbrady91.com/C-Sharp/PEM-Loading-in-dotnet-core-and-dotnet
             key.ImportFromPem(privateKey);
 #else

--- a/src/TrueLayer/TrueLayer.csproj
+++ b/src/TrueLayer/TrueLayer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>TrueLayer</RootNamespace>
     <AssemblyName>TrueLayer.Client</AssemblyName>
     <PackageId>TrueLayer.Client</PackageId>

--- a/test/TrueLayer.AcceptanceTests/TrueLayer.AcceptanceTests.csproj
+++ b/test/TrueLayer.AcceptanceTests/TrueLayer.AcceptanceTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>net5.0</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <RootNamespace>TrueLayer.AcceptanceTests</RootNamespace>
       <AssemblyName>TrueLayer.AcceptanceTests</AssemblyName>

--- a/test/TrueLayer.Benchmarks/TrueLayer.Benchmarks.csproj
+++ b/test/TrueLayer.Benchmarks/TrueLayer.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable;</WarningsAsErrors>
   </PropertyGroup>

--- a/test/TrueLayer.Tests/TrueLayer.Tests.csproj
+++ b/test/TrueLayer.Tests/TrueLayer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable;</WarningsAsErrors>


### PR DESCRIPTION
### Context

`.NET 5` is not supported anymore since [May 10, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). That's why we need to migrate to `.NET 6`.

We're also updating all the [predefined preprocessor symbols](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).