### PR TITLE
[NETSDK-1] Add reference field to Beneficiary.MerchantAccount

### DIFF
--- a/src/TrueLayer/Payments/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payments/Model/Beneficiary.cs
@@ -29,15 +29,20 @@ namespace TrueLayer.Payments.Model
             public string Type => "merchant_account";
 
             /// <summary>
-            /// Gets the TrueLayer merchant account identifier
+            /// Gets or sets the TrueLayer merchant account identifier
             /// </summary>
             public string MerchantAccountId { get; }
 
             /// <summary>
-            /// The name of the beneficiary.
+            /// Gets or sets the name of the beneficiary.
             /// If unspecified, the API will use the account owner name associated to the selected merchant account.
             /// </summary>
             public string? AccountHolderName { get; init; }
+
+            /// <summary>
+            /// Gets or sets A reference for the payment. Not visible to the remitter.
+            /// </summary>
+            public string? Reference { get; init; }
         }
 
         /// <summary>

--- a/src/TrueLayer/Payments/Model/Beneficiary.cs
+++ b/src/TrueLayer/Payments/Model/Beneficiary.cs
@@ -29,18 +29,18 @@ namespace TrueLayer.Payments.Model
             public string Type => "merchant_account";
 
             /// <summary>
-            /// Gets or sets the TrueLayer merchant account identifier
+            /// Gets the TrueLayer merchant account identifier
             /// </summary>
             public string MerchantAccountId { get; }
 
             /// <summary>
-            /// Gets or sets the name of the beneficiary.
+            /// Gets or inits the name of the beneficiary.
             /// If unspecified, the API will use the account owner name associated to the selected merchant account.
             /// </summary>
             public string? AccountHolderName { get; init; }
 
             /// <summary>
-            /// Gets or sets A reference for the payment. Not visible to the remitter.
+            /// Gets or inits A reference for the payment. Not visible to the remitter.
             /// </summary>
             public string? Reference { get; init; }
         }

--- a/src/TrueLayer/Payments/Model/PaymentMethod.cs
+++ b/src/TrueLayer/Payments/Model/PaymentMethod.cs
@@ -36,12 +36,12 @@ namespace TrueLayer.Payments.Model
             public string Type => "bank_transfer";
 
             /// <summary>
-            /// Gets or sets the provider selection options
+            /// Gets or inits the provider selection options
             /// </summary>
             public ProviderUnion ProviderSelection { get; init; }
 
             /// <summary>
-            /// Gets or sets the beneficiary details
+            /// Gets or inits the beneficiary details
             /// </summary>
             public BeneficiaryUnion Beneficiary { get; init; }
         }

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -19,7 +19,7 @@ namespace TrueLayer.Payments.Model
             public string Type => "user_selected";
 
             /// <summary>
-            /// Gets or sets the filter used to determine the banks that should be displayed on the bank selection screen
+            /// Gets or inits the filter used to determine the banks that should be displayed on the bank selection screen
             /// </summary>
             public ProviderFilter? Filter { get; init; }
 
@@ -64,7 +64,7 @@ namespace TrueLayer.Payments.Model
             public string SchemeId { get; }
 
             /// <summary>
-            /// Gets or sets the account details for the remitter
+            /// Gets or inits the account details for the remitter
             /// </summary>
             public RemitterAccount? Remitter { get; init; }
         }

--- a/src/TrueLayer/Payments/Model/ProviderFilter.cs
+++ b/src/TrueLayer/Payments/Model/ProviderFilter.cs
@@ -6,7 +6,7 @@ namespace TrueLayer.Payments.Model
     public record ProviderFilter
     {
         /// <summary>
-        /// Gets or sets the an array of ISO 3166-1 alpha-2 country codes used to filter providers e.g. GB.
+        /// Gets or inits the an array of ISO 3166-1 alpha-2 country codes used to filter providers e.g. GB.
         /// </summary>
         public string[]? Countries { get; init; }
 
@@ -18,26 +18,26 @@ namespace TrueLayer.Payments.Model
         public string? ReleaseChannel { get; init; }
 
         /// <summary>
-        /// Gets or sets the customer segments catered to by a provider that should be returned.
+        /// Gets or inits the customer segments catered to by a provider that should be returned.
         /// See <see cref="CustomerSegments"/>.
         /// </summary>
         /// <example>CustomerSegments.Business</example>
         public string? CustomerSegments { get; init; }
 
         /// <summary>
-        /// Gets or sets the identifiers of the specific providers that should be returned.
+        /// Gets or inits the identifiers of the specific providers that should be returned.
         /// </summary>
         public string[]? ProviderIds { get; init; }
 
         /// <summary>
-        /// Gets or sets the filters used to exclude specific providers
+        /// Gets or inits the filters used to exclude specific providers
         /// </summary>
         public ExcludesFilter? Excludes { get; init; }
 
         public record ExcludesFilter
         {
             /// <summary>
-            /// Gets or sets the identifiers of the specific providers that should be excluded
+            /// Gets or inits the identifiers of the specific providers that should be excluded
             /// </summary>
             /// <value></value>
             public string[]? ProviderIds { get; init; }

--- a/src/TrueLayer/TrueLayerOptions.cs
+++ b/src/TrueLayer/TrueLayerOptions.cs
@@ -11,17 +11,17 @@ namespace TrueLayer
     public class TrueLayerOptions
     {
         /// <summary>
-        /// Gets or sets your TrueLayer client id.
+        /// Gets or inits your TrueLayer client id.
         /// </summary>
         public string? ClientId { get; init; }
 
         /// <summary>
-        /// Gets or sets your TrueLayer client secret.
+        /// Gets or inits your TrueLayer client secret.
         /// </summary>
         public string? ClientSecret { get; init; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to connect to the TrueLayer Sandbox.
+        /// Gets or inits a value indicating whether to connect to the TrueLayer Sandbox.
         /// </summary>
         public bool? UseSandbox { get; init; }
 

--- a/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
+++ b/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
@@ -95,7 +95,10 @@ namespace TrueLayer.AcceptanceTests
                     {
                         Filter = new ProviderFilter { ProviderIds = new[] { "mock-payments-gb-redirect" } }
                     },
-                    new Beneficiary.MerchantAccount(merchantId)),
+                    new Beneficiary.MerchantAccount(merchantId)
+                    {
+                        Reference = "Test payment",
+                    }),
                 new PaymentUserRequest("Jane Doe", email: "jane.doe@example.com", phone: "+442079460087")
             );
     }


### PR DESCRIPTION
The [`Beneficiary.MerchantAccount`](https://github.com/TrueLayer/truelayer-dotnet/blob/main/src/TrueLayer/Payments/Model/Beneficiary.cs#L15) request record doesn't currently allow to specify the `Reference` for the payment request as specified in the [documentation](https://docs.truelayer.com/reference/create-payment).

This PR adds the field to the request object.

Extra:
- Fixed xml doc for some of the properties in record objects