### PR TITLE
feat(PAYG-1374): Remove user info from get payment response

### DIFF
--- a/src/TrueLayer/Payments/Model/PaymentUser.cs
+++ b/src/TrueLayer/Payments/Model/PaymentUser.cs
@@ -3,5 +3,5 @@ namespace TrueLayer.Payments.Model
     /// <summary>
     /// Represents an end user
     /// </summary>
-    public record PaymentUser(string Id, string? Name = null, string? Email = null, string? Phone = null);
+    public record PaymentUser(string Id);
 }

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -92,9 +92,6 @@ namespace TrueLayer.AcceptanceTests
             payment.PaymentMethod.AsT0.Beneficiary.ShouldBe(paymentRequest.PaymentMethod.AsT0.Beneficiary);
             payment.User.ShouldNotBeNull();
             payment.User.Id.ShouldBe(authorizationRequiredResponse.User.Id);
-            payment.User.Name.ShouldBe(paymentRequest.User!.Name);
-            payment.User.Email.ShouldBe(paymentRequest.User!.Email);
-            payment.User.Phone.ShouldBe(paymentRequest.User!.Phone);
         }
 
         private static CreatePaymentRequest CreateTestPaymentRequest(


### PR DESCRIPTION
**Description:** 
Remove user info from the `GET /payment` response.

**Changelog:**
https://docs.truelayer.com/changelog/removal-of-user-info-in-payment-and-mandate-response

**Updated documentation**
https://docs.truelayer.com/reference/get-payment-1
https://docs.truelayer.com/reference/get-mandate