### PR TITLE
fix: [EWT-80] Change `CustomerSegments` to array accordingly with PaymentV3 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.0] - 2023-01-20
+### Changed
+- `ProviderFilters.CustomerSegments` is now an array.
+
 ## [0.3.0] - 2022-10-31
 ### Changed
 - Upgrade to `.NET6`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.0.0] - 2023-01-20
+## [1.0.0] - 2023-01-23
 ### Changed
 - `ProviderFilters.CustomerSegments` is now an array.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.0.0] - 2023-01-23
-### Changed
-- `ProviderFilters.CustomerSegments` is now an array.
-
 ## [0.3.0] - 2022-10-31
 ### Changed
 - Upgrade to `.NET6`.

--- a/src/TrueLayer/Payments/Model/ProviderFilter.cs
+++ b/src/TrueLayer/Payments/Model/ProviderFilter.cs
@@ -19,10 +19,9 @@ namespace TrueLayer.Payments.Model
 
         /// <summary>
         /// Gets or inits the customer segments catered to by a provider that should be returned.
-        /// See <see cref="CustomerSegments"/>.
+        /// For the accepted value see <see cref="TrueLayer.CustomerSegments"/>.
         /// </summary>
-        /// <example>CustomerSegments.Business</example>
-        public string? CustomerSegments { get; init; }
+        public string[]? CustomerSegments { get; init; }
 
         /// <summary>
         /// Gets or inits the identifiers of the specific providers that should be returned.

--- a/src/TrueLayer/Payments/Model/ProviderFilter.cs
+++ b/src/TrueLayer/Payments/Model/ProviderFilter.cs
@@ -19,7 +19,7 @@ namespace TrueLayer.Payments.Model
 
         /// <summary>
         /// Gets or inits the customer segments catered to by a provider that should be returned.
-        /// For the accepted value see <see cref="TrueLayer.CustomerSegments"/>.
+        /// For the accepted values see <see cref="TrueLayer.CustomerSegments"/>.
         /// </summary>
         public string[]? CustomerSegments { get; init; }
 


### PR DESCRIPTION
This is a **breaking change** since the field is changed from `string` to `string[]`.