### PR TITLE
Add build Hpp for mandates

### DIFF
--- a/src/TrueLayer/Payments/Enums/HppType.cs
+++ b/src/TrueLayer/Payments/Enums/HppType.cs
@@ -1,0 +1,8 @@
+namespace TrueLayer.Payments.Enums
+{
+    public enum HppType
+    {
+        Payment = 0,
+        Mandate = 1
+    }
+}

--- a/src/TrueLayer/Payments/HppLinkBuilder.cs
+++ b/src/TrueLayer/Payments/HppLinkBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using TrueLayer.Payments.Enums;
 
 namespace TrueLayer.Payments
 {
@@ -12,20 +13,23 @@ namespace TrueLayer.Payments
         public HppLinkBuilder(Uri? baseUri = null, bool useSandbox = true)
         {
             _baseUri = baseUri ??
-                new Uri((useSandbox) ? SandboxUrl : ProdUrl);
+                       new Uri((useSandbox) ? SandboxUrl : ProdUrl);
         }
 
-        public string Build(string paymentId, string paymentToken, Uri returnUri)
+        public string Build(string id, string token, Uri returnUri, HppType hppType = HppType.Payment)
         {
-            paymentId.NotNullOrWhiteSpace(nameof(paymentId));
-            paymentToken.NotNullOrWhiteSpace(nameof(paymentToken));
+            id.NotNullOrWhiteSpace(nameof(id));
+            token.NotNullOrWhiteSpace(nameof(token));
             returnUri.NotNull(nameof(returnUri));
 
-            var fragment = $"payment_id={paymentId}&resource_token={paymentToken}&return_uri={returnUri.AbsoluteUri}";
+            var idName = hppType == HppType.Payment ? "payment_id" : "mandate_id";
+            var fragment = $"{idName}={id}&resource_token={token}&return_uri={returnUri.AbsoluteUri}";
 
-            var builder = new UriBuilder(_baseUri);
-            builder.Path = "payments";
-            builder.Fragment = fragment;
+            var builder = new UriBuilder(_baseUri)
+            {
+                Path = hppType == HppType.Payment ? "payments" : "mandates",
+                Fragment = fragment
+            };
 
             return builder.Uri.AbsoluteUri;
         }


### PR DESCRIPTION
Currently, the HppLinkBuilder.Build method only works for payments. Mandates also have an hosted-page, so this method can now do both.