### PR TITLE
feat(EWT-111): Add more user info to the payment user request

### DIFF
--- a/examples/MvcExample/Controllers/HomeController.cs
+++ b/examples/MvcExample/Controllers/HomeController.cs
@@ -50,7 +50,8 @@ namespace MvcExample.Controllers
                         "TrueLayer",
                         "truelayer-dotnet",
                         new AccountIdentifier.SortCodeAccountNumber("567890", "12345678"))),
-                new PaymentUserRequest(name: donateModel.Name, email: donateModel.Email)
+                new PaymentUserRequest(name: donateModel.Name, email: donateModel.Email, dateOfBirth: new DateTime(1999, 1, 1),
+                    address: new Address("London", "England", "EC1R 4RB", "GB", "1 Hardwick St", "Awesome building"))
             );
 
             var apiResponse = await _truelayer.Payments.CreatePayment(

--- a/src/TrueLayer/Payments/Model/Address.cs
+++ b/src/TrueLayer/Payments/Model/Address.cs
@@ -1,0 +1,53 @@
+namespace TrueLayer.Payments.Model;
+
+public record Address
+{
+    /// <summary>
+    /// Represents a physical address
+    /// </summary>
+    public Address(
+        string city,
+        string state,
+        string zip,
+        string countryCode,
+        string addressLine1,
+        string? addressLine2 = null)
+    {
+        AddressLine1 = addressLine1.NotNullOrWhiteSpace(nameof(addressLine1));
+        AddressLine2 = addressLine2.NotEmptyOrWhiteSpace(nameof(addressLine2));
+        City = city.NotNullOrWhiteSpace(nameof(city));
+        State = state.NotNullOrWhiteSpace(nameof(state));
+        Zip = zip.NotNullOrWhiteSpace(nameof(zip));
+        CountryCode = countryCode.NotNullOrWhiteSpace(nameof(countryCode));
+    }
+
+    /// <summary>
+    /// Gets full street address including house number and street name.
+    /// </summary>
+    public string AddressLine1 { get; }
+        
+    /// <summary>
+    /// Gets details like building name, suite, apartment number, etc.
+    /// </summary>
+    public string? AddressLine2 { get; }
+        
+    /// <summary>
+    /// Gets the name of the city / locality.
+    /// </summary>
+    public string City { get; }
+        
+    /// <summary>
+    /// Gets the name of the country / stat.
+    /// </summary>
+    public string State { get; }
+        
+    /// <summary>
+    /// Gets the zip code or postal code
+    /// </summary>
+    public string Zip { get; }
+
+    /// <summary>
+    /// Gets the country code according to ISO-3166-1 alpha-2
+    /// </summary>
+    public string CountryCode { get; }
+}

--- a/src/TrueLayer/Payments/Model/PaymentUserRequest.cs
+++ b/src/TrueLayer/Payments/Model/PaymentUserRequest.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Text.Json.Serialization;
+using TrueLayer.Serialization;
+
 namespace TrueLayer.Payments.Model
 {
     /// <summary>
@@ -11,11 +15,21 @@ namespace TrueLayer.Payments.Model
         /// <param name="name">The user's name.</param>
         /// <param name="email">The user's email address.</param>
         /// <param name="phone">The user's phone number.</param>
-        public PaymentUserRequest(string? name = null, string? email = null, string? phone = null)
+        /// <param name="dateOfBirth">The user's date of birth</param>
+        /// <param name="address">The user's physical address</param>
+        public PaymentUserRequest(
+            string? name = null,
+            string? email = null,
+            string? phone = null,
+            DateTime? dateOfBirth = null,
+            Address? address = null)
         {
+            Address = address;
             Name = name.NotEmptyOrWhiteSpace(nameof(name));
             Email = email.NotEmptyOrWhiteSpace(nameof(email));
             Phone = phone.NotEmptyOrWhiteSpace(nameof(phone));
+            DateOfBirth = dateOfBirth?.Date;
+            Address = address;
         }
 
         /// <summary>
@@ -25,12 +39,22 @@ namespace TrueLayer.Payments.Model
         /// <param name="name">The user's name</param>
         /// <param name="email">The user's email address.</param>
         /// <param name="phone">The user's phone number.</param>
-        public PaymentUserRequest(string id, string? name = null, string? email = null, string? phone = null)
+        /// <param name="dateOfBirth">The user's date of birth</param>
+        /// <param name="address">The user's physical address</param>
+        public PaymentUserRequest(
+            string id,
+            string? name = null,
+            string? email = null,
+            string? phone = null,
+            DateTime? dateOfBirth = null,
+            Address? address = null)
         {
             Id = id.NotNullOrWhiteSpace(nameof(id));
             Name = name.NotEmptyOrWhiteSpace(nameof(name));
             Email = email.NotEmptyOrWhiteSpace(nameof(email));
             Phone = phone.NotEmptyOrWhiteSpace(nameof(phone));
+            DateOfBirth = dateOfBirth?.Date;
+            Address = address;
         }
 
         /// <summary>
@@ -52,5 +76,16 @@ namespace TrueLayer.Payments.Model
         /// Gets the user's phone number.
         /// </summary>
         public string? Phone { get; }
+        
+        /// <summary>
+        /// Gets the user's date of birth.
+        /// </summary>
+        [JsonConverter(typeof(DateTimeDateOnlyJsonConverter))]
+        public DateTime? DateOfBirth { get; }
+        
+        /// <summary>
+        /// Gets the user's physical address
+        /// </summary>
+        public Address? Address { get; }
     }
 }

--- a/src/TrueLayer/Serialization/DateTimeDateOnlyJsonConverter.cs
+++ b/src/TrueLayer/Serialization/DateTimeDateOnlyJsonConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TrueLayer.Serialization;
+
+internal sealed class DateTimeDateOnlyJsonConverter : JsonConverter<DateTime>
+{
+    private const string Format = "yyyy-MM-dd";
+
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return DateTime.ParseExact(reader.GetString()!, Format, CultureInfo.InvariantCulture);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString(Format, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/TrueLayer/TrueLayer.csproj
+++ b/src/TrueLayer/TrueLayer.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="jose-jwt" Version="3.2.0" />
     <PackageReference Include="OneOf" Version="3.0.201" />
     <PackageReference Include="TrueLayer.Signing" Version="0.1.11" />
-</ItemGroup>
-<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Text.Json" Version="[5.0.2,6.0)" />
     <PackageReference Include="Microsoft.CSharp" Version="[4.7,5.0)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="[4.7,6.0]" />

--- a/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
+++ b/test/TrueLayer.AcceptanceTests/MerchantAccountsTests.cs
@@ -99,7 +99,12 @@ namespace TrueLayer.AcceptanceTests
                     {
                         Reference = "Test payment",
                     }),
-                new PaymentUserRequest("Jane Doe", email: "jane.doe@example.com", phone: "+442079460087")
+                new PaymentUserRequest(
+                    name: "Jane Doe", 
+                    email: "jane.doe@example.com",
+                    phone: "+442079460087",
+                    dateOfBirth: new DateTime(1999, 1, 1),
+                    address: new Address("London", "England", "EC1R 4RB", "GB", "1 Hardwick St"))
             );
     }
 }

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -108,7 +108,12 @@ namespace TrueLayer.AcceptanceTests
                         "truelayer-dotnet",
                         accountIdentifier
                     )),
-                new PaymentUserRequest("Jane Doe", email: "jane.doe@example.com", phone: "+44 1234 567890")
+                new PaymentUserRequest(
+                    name: "Jane Doe", 
+                    email: "jane.doe@example.com",
+                    phone: "+442079460087",
+                    dateOfBirth: new DateTime(1999, 1, 1),
+                    address: new Address("London", "England", "EC1R 4RB", "GB", "1 Hardwick St"))
             );
 
         private static IEnumerable<object[]> CreateTestPaymentRequests()

--- a/test/TrueLayer.Tests/Payments/AddressTests.cs
+++ b/test/TrueLayer.Tests/Payments/AddressTests.cs
@@ -1,0 +1,66 @@
+using System;
+using TrueLayer.Payments.Model;
+using Xunit;
+
+namespace TrueLayer.Tests.Payments;
+
+public class AddressTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void New_address_throws_if_address_line_1_empty_or_whitespace(string addressLine1)
+    {
+        Assert.Throws<ArgumentException>("addressLine1",
+            () => new Address("city", "state", "country Code", "zip", addressLine1));
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void New_address_throws_if_city_null_or_empty(string city)
+    {
+        Assert.Throws<ArgumentException>("city",
+            () => new Address(city, "state", "zip", "country Code", "addressLine1"));
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void New_address_throws_if_state_null_or_empty(string state)
+    {
+        Assert.Throws<ArgumentException>("state",
+            () => new Address("city", state, "zip", "country Code", "addressLine1"));
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void New_address_throws_if_zip_null_or_empty(string zip)
+    {
+        Assert.Throws<ArgumentException>("zip",
+            () => new Address("city", "state", zip, "country Code", "addressLine1"));
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void New_address_throws_if_country_code_null_or_empty(string countryCode)
+    {
+        Assert.Throws<ArgumentException>("countryCode",
+            () => new Address("city", "state", "zip", countryCode, "addressLine1"));
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void New_address_throws_if_address_line_2_null_or_empty(string addressLine2)
+    {
+        Assert.Throws<ArgumentException>("addressLine2",
+            () => new Address("city", "state", "zip", "countryCode", "addressLine1", addressLine2));
+    }
+}

--- a/test/TrueLayer.Tests/Payments/PaymentUserRequestTests.cs
+++ b/test/TrueLayer.Tests/Payments/PaymentUserRequestTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Shouldly;
 using TrueLayer.Payments.Model;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_throws_if_name_empty_or_whitespace(string name)
         {
-            Assert.Throws<ArgumentException>("name", () => new PaymentUserRequest(name, null, null));
+            Assert.Throws<ArgumentException>("name", () => new PaymentUserRequest(name, null, null, null, null));
         }
 
         [Theory]
@@ -19,7 +20,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_throws_if_email_empty_or_whitespace(string email)
         {
-            Assert.Throws<ArgumentException>("email", () => new PaymentUserRequest(null, email, null));
+            Assert.Throws<ArgumentException>("email", () => new PaymentUserRequest(null, email, null, null, null));
         }
 
         [Theory]
@@ -27,7 +28,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_throws_if_phone_empty_or_whitespace(string phone)
         {
-            Assert.Throws<ArgumentException>("phone", () => new PaymentUserRequest(null, null, phone));
+            Assert.Throws<ArgumentException>("phone", () => new PaymentUserRequest(null, null, phone, null, null));
         }
 
         [Theory]
@@ -36,7 +37,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_with_id_throws_if_id_null_or_whitespace(string? id)
         {
-            Assert.Throws<ArgumentException>("id", () => new PaymentUserRequest(id!, null, null, null));
+            Assert.Throws<ArgumentException>("id", () => new PaymentUserRequest(id!, null, null, null, null, null));
         }
 
         [Theory]
@@ -44,7 +45,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_with_id_throws_if_name_empty_or_whitespace(string name)
         {
-            Assert.Throws<ArgumentException>("name", () => new PaymentUserRequest("id", name, null, null));
+            Assert.Throws<ArgumentException>("name", () => new PaymentUserRequest("id", name, null, null, null, null));
         }
 
         [Theory]
@@ -52,7 +53,7 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_with_id_throws_if_email_empty_or_whitespace(string email)
         {
-            Assert.Throws<ArgumentException>("email", () => new PaymentUserRequest("id", null, email, null));
+            Assert.Throws<ArgumentException>("email", () => new PaymentUserRequest("id", null, email, null, null, null));
         }
 
         [Theory]
@@ -60,7 +61,19 @@ namespace TrueLayer.Tests.Payments
         [InlineData(" ")]
         public void New_user_with_id_throws_if_phone_empty_or_whitespace(string phone)
         {
-            Assert.Throws<ArgumentException>("phone", () => new PaymentUserRequest("id", null, null, phone));
+            Assert.Throws<ArgumentException>("phone", () => new PaymentUserRequest("id", null, null, phone, null, null));
+        }
+
+        [Fact]
+        public void New_user_with_date_of_birth_gets_only_date_part_of_it()
+        {
+            // Arrange
+            var dob = new DateTime(1969, 12, 28, 12, 33, 55);
+            var user = new PaymentUserRequest(id: "id", dateOfBirth: dob);
+            
+            user.DateOfBirth.HasValue.ShouldBeTrue();
+            user.DateOfBirth!.Value.ShouldBeEquivalentTo(new DateTime(1969, 12, 28));
+            user.DateOfBirth!.Value.TimeOfDay.ShouldBeEquivalentTo(TimeSpan.Zero);
         }
     }
 }


### PR DESCRIPTION
This PRs adds the following field to the `PaymentUserRequest` object to align it with the official [documentation](https://docs.truelayer.com/reference/create-payment):
- `DateOfBirth` (with custom JSON formatter to serialise it to `"yyyy-MM-dd"`)
- `Address`

Amended test and sample app accordingly.