### PR TITLE
[EWT-111]: updated CHANGELOG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
         default: 'false'
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.1.0] - 2023-02-22
-### Added
-- `Address` and `DateofBirth` to `PaymentUserRequest`.
+### Unlisted
+- ~~`Address` and `DateofBirth` to `PaymentUserRequest`.~~
+- This version got unlisted because wrong. Please refer to version `1.2.0`.
 
 ## [1.0.0] - 2023-01-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2023-03-06
+### Added
+- `Address` and `DateofBirth` to `PaymentUserRequest`.
+
 ## [1.1.0] - 2023-02-22
 ### Unlisted
 - ~~`Address` and `DateofBirth` to `PaymentUserRequest`.~~

--- a/TrueLayer.sln
+++ b/TrueLayer.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		docs\index.md = docs\index.md
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
+		CHANGELOG.md = CHANGELOG.md
+		SECURITY.md = SECURITY.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{CD513AC9-E9A5-4941-A131-678BCE9DB2B0}"


### PR DESCRIPTION
New tag 1.2.0 got pushed to replace version 1.1.0.
Updated the changelog accordingly.

Extra:
- updated workflows runner to `ubunto-22.04` (see [this issue](https://github.com/actions/runner-images/issues/6002) for more details)