### PR TITLE
feat(pfi-305): implement new scheme selection option when creating a payment

### DIFF
--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -1,7 +1,13 @@
+using System;
+using OneOf;
 using TrueLayer.Serialization;
+using static TrueLayer.Payments.Model.SchemeSelection;
 
 namespace TrueLayer.Payments.Model
 {
+    using PreselectedSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, Preselected, UserSelected>;
+    using UserSelectedSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, UserSelected>;
+
     /// <summary>
     /// Provider types
     /// </summary>
@@ -33,7 +39,13 @@ namespace TrueLayer.Payments.Model
             /// Gets the id of the scheme associated to the selected provider that was used to make the payment over.
             /// The field is populated only when a <see cref="GetPaymentResponse"/> is returned
             /// </summary>
+            [Obsolete("The field will be removed soon. Please start using the new <see cref=\"SchemeSelection\"/> field.", error: false)]
             public string? SchemeId { get; init; }
+
+            /// <summary>
+            /// Gets or inits the scheme selection preferred to make the payment.
+            /// </summary>
+            public UserSelectedSchemeSelectionUnion? SchemeSelection { get; init; }
         }
 
         /// <summary>
@@ -46,6 +58,12 @@ namespace TrueLayer.Payments.Model
             {
                 ProviderId = providerId.NotNull(nameof(providerId));
                 SchemeId = schemeId.NotNull(nameof(schemeId));
+            }
+
+            public Preselected(string providerId, PreselectedSchemeSelectionUnion schemeSelection)
+            {
+                ProviderId = providerId.NotNull(nameof(providerId));
+                SchemeSelection = schemeSelection.NotNull(nameof(providerId));
             }
 
             /// <summary>
@@ -61,12 +79,20 @@ namespace TrueLayer.Payments.Model
             /// <summary>
             /// Gets the id of the scheme to make the payment over
             /// </summary>
-            public string SchemeId { get; }
+            [Obsolete(
+                "The field will be removed soon. Please start using the new <see cref=\"SchemeSelection\"/> field.",
+                error: false)]
+            public string? SchemeId { get; } = null;
 
             /// <summary>
             /// Gets or inits the account details for the remitter
             /// </summary>
             public RemitterAccount? Remitter { get; init; }
+
+            /// <summary>
+            /// Gets or inits the scheme selection preferred to make the payment.
+            /// </summary>
+            public PreselectedSchemeSelectionUnion? SchemeSelection { get; init; }
         }
     }
 }

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -1,12 +1,13 @@
 using System;
+using System.Text.Json.Serialization;
 using OneOf;
 using TrueLayer.Serialization;
 using static TrueLayer.Payments.Model.SchemeSelection;
 
 namespace TrueLayer.Payments.Model
 {
-    using PreselectedSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, Preselected, UserSelected>;
-    using UserSelectedSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, UserSelected>;
+    using PreselectedProviderSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, Preselected, UserSelected>;
+    using UserSelectedProviderSchemeSelectionUnion = OneOf<InstantOnly, InstantPreferred, UserSelected>;
 
     /// <summary>
     /// Provider types
@@ -45,7 +46,7 @@ namespace TrueLayer.Payments.Model
             /// <summary>
             /// Gets or inits the scheme selection preferred to make the payment.
             /// </summary>
-            public UserSelectedSchemeSelectionUnion? SchemeSelection { get; init; }
+            public UserSelectedProviderSchemeSelectionUnion? SchemeSelection { get; init; }
         }
 
         /// <summary>
@@ -54,16 +55,16 @@ namespace TrueLayer.Payments.Model
         [JsonDiscriminator("preselected")]
         public record Preselected : IDiscriminated
         {
-            public Preselected(string providerId, string schemeId)
+            public Preselected(string providerId, string? schemeId = null, PreselectedProviderSchemeSelectionUnion? schemeSelection = null)
             {
-                ProviderId = providerId.NotNull(nameof(providerId));
-                SchemeId = schemeId.NotNull(nameof(schemeId));
-            }
+                if (string.IsNullOrWhiteSpace(schemeId) && schemeSelection is null)
+                {
+                    throw new ArgumentException("Please specify either the SchemeId or the SchemeSelection option");
+                }
 
-            public Preselected(string providerId, PreselectedSchemeSelectionUnion schemeSelection)
-            {
                 ProviderId = providerId.NotNull(nameof(providerId));
-                SchemeSelection = schemeSelection.NotNull(nameof(providerId));
+                SchemeId = schemeId;
+                SchemeSelection = schemeSelection;
             }
 
             /// <summary>
@@ -92,7 +93,7 @@ namespace TrueLayer.Payments.Model
             /// <summary>
             /// Gets or inits the scheme selection preferred to make the payment.
             /// </summary>
-            public PreselectedSchemeSelectionUnion? SchemeSelection { get; init; }
+            public PreselectedProviderSchemeSelectionUnion? SchemeSelection { get; init; }
         }
     }
 }

--- a/src/TrueLayer/Payments/Model/SchemeSelection.cs
+++ b/src/TrueLayer/Payments/Model/SchemeSelection.cs
@@ -69,5 +69,10 @@ public static class SchemeSelection
         /// Gets the scheme selection type
         /// </summary>
         public string Type => "preselected";
+
+        /// <summary>
+        ///
+        /// </summary>
+        public string? SchemeId { get; init; }
     }
 }

--- a/src/TrueLayer/Payments/Model/SchemeSelection.cs
+++ b/src/TrueLayer/Payments/Model/SchemeSelection.cs
@@ -1,0 +1,73 @@
+using TrueLayer.Serialization;
+
+namespace TrueLayer.Payments.Model;
+
+/// <summary>
+/// Scheme selection types
+/// </summary>
+public static class SchemeSelection
+{
+    /// <summary>
+    /// Represents that the scheme for the payment allows only providers that support instant payments.
+    /// </summary>
+    [JsonDiscriminator("instant_only")]
+    public record InstantOnly : IDiscriminated
+    {
+        /// <summary>
+        /// Gets the scheme selection type
+        /// </summary>
+        public string Type => "instant_only";
+
+        /// <summary>
+        /// Gets or inits the setting to allow providers to possibly charge the remitter with a transaction fee.
+        /// If false, only providers supporting schemes that are free will be available to select in the provider
+        /// selection action.
+        /// Unless explicitly set, will default to false.
+        /// </summary>
+        public bool AllowRemitterFee { get; init; } = false;
+    }
+
+    /// <summary>
+    /// Represents that the scheme for the payment will prefer providers that allow instant payments,
+    /// but allow defaulting back to non-instant payments if unavailable.
+    /// </summary>
+    [JsonDiscriminator("instant_preferred")]
+    public record InstantPreferred : IDiscriminated
+    {
+        /// <summary>
+        /// Gets the scheme selection type
+        /// </summary>
+        public string Type => "instant_preferred";
+
+        /// <summary>
+        /// Gets or inits the setting to allow providers to possibly charge the remitter with a transaction fee.
+        /// If false, only providers supporting schemes that are free will be available to select in the provider selection action.
+        /// Unless explicitly set, will default to false.
+        /// </summary>
+        public bool AllowRemitterFee { get; init; } = false;
+    }
+
+    /// <summary>
+    /// Represents that the scheme for the payment is selected from a collection.
+    /// </summary>
+    [JsonDiscriminator("user_selected")]
+    public record UserSelected : IDiscriminated
+    {
+        /// <summary>
+        /// Gets the scheme selection type
+        /// </summary>
+        public string Type => "user_selected";
+    }
+
+    /// <summary>
+    /// Represents that the scheme for the payment is preselected.
+    /// </summary>
+    [JsonDiscriminator("preselected")]
+    public record Preselected : IDiscriminated
+    {
+        /// <summary>
+        /// Gets the scheme selection type
+        /// </summary>
+        public string Type => "preselected";
+    }
+}


### PR DESCRIPTION
This PR implements the new scheme selection options from the [CreatePAyment](https://docs.truelayer.com/reference/create-payment) request that are replacing the old structure based on `scheme_id`.