### PR TITLE
feat(PAYINS-504): Set Authorization header to `GET v3/payments-providers/{id}`

### DIFF
--- a/src/TrueLayer/TrueLayerClient.cs
+++ b/src/TrueLayer/TrueLayerClient.cs
@@ -26,7 +26,7 @@ namespace TrueLayer
 
             Auth = new AuthApi(apiClient, options.Value);
             _payments = new(() => new PaymentsApi(apiClient, Auth, options.Value));
-            _paymentsProviders = new(() => new PaymentsProvidersApi(apiClient, options.Value));
+            _paymentsProviders = new(() => new PaymentsProvidersApi(apiClient, Auth, options.Value));
             _payouts = new(() => new PayoutsApi(apiClient, Auth, options.Value));
             _merchants = new(() => new MerchantAccountsApi(apiClient, Auth, options.Value));
             _mandates = new(() => new MandatesApi(apiClient, Auth, options.Value));


### PR DESCRIPTION
The endpoint now requires `Authorization` header.
The `client_id` query parameter is not needed anymore as it is fetched from the token's claims.