### PR TITLE
Update TrueLayerServiceCollectionExtensions.cs

### DIFF
--- a/src/TrueLayer/TrueLayerServiceCollectionExtensions.cs
+++ b/src/TrueLayer/TrueLayerServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Configuration;
 using TrueLayer;
 
@@ -28,18 +28,17 @@ namespace Microsoft.Extensions.DependencyInjection
             if (services is null) throw new ArgumentNullException(nameof(services));
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
 
-            services.Configure<TrueLayerOptions>(options =>
+            services.Configure<TrueLayerOptions>(configurationSectionName, options =>
             {
                 configuration.GetSection(configurationSectionName).Bind(options);
                 configureOptions?.Invoke(options);
                 options.Validate();
             });
 
-            //Allow naming of the Service to recall - Allows to have multiple configurations within the same web project
             IHttpClientBuilder httpClientBuilder = services.AddHttpClient<IApiClient, ApiClient>(configurationSectionName);
             configureBuilder?.Invoke(httpClientBuilder);
 
-            services.AddTransient<ITrueLayerClient, TrueLayerClient>();
+            services.AddKeyedTransient<ITrueLayerClient, TrueLayerClient>(configurationSectionName);
 
             return services;
         }

--- a/src/TrueLayer/TrueLayerServiceCollectionExtensions.cs
+++ b/src/TrueLayer/TrueLayerServiceCollectionExtensions.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.Validate();
             });
 
-            IHttpClientBuilder httpClientBuilder = services.AddHttpClient<IApiClient, ApiClient>();
+            //Allow naming of the Service to recall - Allows to have multiple configurations within the same web project
+            IHttpClientBuilder httpClientBuilder = services.AddHttpClient<IApiClient, ApiClient>(configurationSectionName);
             configureBuilder?.Invoke(httpClientBuilder);
 
             services.AddTransient<ITrueLayerClient, TrueLayerClient>();


### PR DESCRIPTION
Used the Configuration Section name to name the Client Service through the dependency injection. This allows you to have multiple configuration profiles loaded in the same web project and recall the service by name when you require it.