### PR TITLE
Create ITrueLayerClientResolver.cs

### DIFF
--- a/src/TrueLayer/ITrueLayerClientResolver.cs
+++ b/src/TrueLayer/ITrueLayerClientResolver.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace TrueLayer
+{
+    public interface ITrueLayerClientResolver
+    {
+        ITrueLayerClient GetClientByName(string name);
+    }
+
+    public class TrueLayerClientResolver : ITrueLayerClientResolver
+    {
+        private readonly IServiceProvider _serviceProvider;
+        public TrueLayerClientResolver(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+#pragma warning disable CS8603 // Possible null reference return.
+        public ITrueLayerClient GetClientByName(string name) => _serviceProvider.GetKeyedService<ITrueLayerClient>(name);
+#pragma warning restore CS8603 // Possible null reference return.
+
+    }
+}


### PR DESCRIPTION
Allows recall of Client by Keyed Named.

Example:
Adding into DI
```
services.AddSingleton<ITrueLayerClientResolver, TrueLayerClientResolver>();
services.AddTrueLayer(Configuration, options =>
{
    if (options.Payments?.SigningKey != null)
    {
        options.Payments.SigningKey.PrivateKey = System.IO.File.ReadAllText("private-key2.pem");
    }
},null, "TrueLayer_V1");
services.AddTrueLayer(Configuration, options =>
{
    if (options.Payments?.SigningKey != null)
    {
        options.Payments.SigningKey.PrivateKey = System.IO.File.ReadAllText("private-key2.pem");
    }
}, null, "TrueLayer_V2");

```

Recalling specific service configuration

```
public myController(ITrueLayerClientResolver tlclients)
{
 _tlclient = tlclients.GetClientByName("TrueLayer_V1");
}
```


