### PR TITLE
fix(acl-20): remove unnecessary obsolete tags

### DIFF
--- a/examples/MvcExample/Controllers/HomeController.cs
+++ b/examples/MvcExample/Controllers/HomeController.cs
@@ -102,7 +102,6 @@ namespace MvcExample.Controllers
         }
 
         [HttpGet]
-        [Obsolete]
         public async Task<IActionResult> Complete([FromQuery(Name = "payment_id")] string paymentId)
         {
             if (string.IsNullOrWhiteSpace(paymentId))

--- a/src/TrueLayer/Payments/Model/Provider.cs
+++ b/src/TrueLayer/Payments/Model/Provider.cs
@@ -55,7 +55,6 @@ namespace TrueLayer.Payments.Model
         [JsonDiscriminator("preselected")]
         public record Preselected : IDiscriminated
         {
-            [Obsolete]
             public Preselected(string providerId, string? schemeId = null, PreselectedProviderSchemeSelectionUnion? schemeSelection = null)
             {
                 if (string.IsNullOrWhiteSpace(schemeId) && schemeSelection is null)


### PR DESCRIPTION
#203 introduced made the `Preselected` provider selection method obsolete by mistake. This PR is reverting the change.