### PR TITLE
feat(ACL-132, ACL-134) add support to retry option for the `CreatePAymentRequest` and `attempt_failed`  response type

### DIFF
--- a/examples/MvcExample/Controllers/HomeController.cs
+++ b/examples/MvcExample/Controllers/HomeController.cs
@@ -98,6 +98,11 @@ namespace MvcExample.Controllers
                 {
                     ViewData["Status"] = failed.Status;
                     return View("Failed");
+                },
+                attemptFailed =>
+                {
+                    ViewData["Status"] = attemptFailed.Status;
+                    return View("Failed");
                 });
         }
 

--- a/examples/MvcExample/Controllers/HomeController.cs
+++ b/examples/MvcExample/Controllers/HomeController.cs
@@ -98,11 +98,6 @@ namespace MvcExample.Controllers
                 {
                     ViewData["Status"] = failed.Status;
                     return View("Failed");
-                },
-                attemptFailed =>
-                {
-                    ViewData["Status"] = attemptFailed.Status;
-                    return View("Failed");
                 });
         }
 
@@ -151,7 +146,8 @@ namespace MvcExample.Controllers
                 authorized => SuccessOrPending(authorized),
                 success => SuccessOrPending(success),
                 settled => SuccessOrPending(settled),
-                failed => Failed(failed.Status, failed.PaymentMethod)
+                failed => Failed(failed.Status, failed.PaymentMethod),
+                attemptFailed => Failed(attemptFailed.Status, attemptFailed.PaymentMethod)
             );
         }
 

--- a/src/TrueLayer/Payments/IPaymentsApi.cs
+++ b/src/TrueLayer/Payments/IPaymentsApi.cs
@@ -15,7 +15,8 @@ namespace TrueLayer.Payments
         CreatePaymentResponse.AuthorizationRequired,
         CreatePaymentResponse.Authorized,
         CreatePaymentResponse.Failed,
-        CreatePaymentResponse.Authorizing
+        CreatePaymentResponse.Authorizing,
+        CreatePaymentResponse.AttemptFailed
     >;
     using GetPaymentUnion = OneOf<
         GetPaymentResponse.AuthorizationRequired,

--- a/src/TrueLayer/Payments/IPaymentsApi.cs
+++ b/src/TrueLayer/Payments/IPaymentsApi.cs
@@ -15,8 +15,7 @@ namespace TrueLayer.Payments
         CreatePaymentResponse.AuthorizationRequired,
         CreatePaymentResponse.Authorized,
         CreatePaymentResponse.Failed,
-        CreatePaymentResponse.Authorizing,
-        CreatePaymentResponse.AttemptFailed
+        CreatePaymentResponse.Authorizing
     >;
     using GetPaymentUnion = OneOf<
         GetPaymentResponse.AuthorizationRequired,
@@ -24,7 +23,8 @@ namespace TrueLayer.Payments
         GetPaymentResponse.Authorized,
         GetPaymentResponse.Executed,
         GetPaymentResponse.Settled,
-        GetPaymentResponse.Failed
+        GetPaymentResponse.Failed,
+        GetPaymentResponse.AttemptFailed
     >;
 
     using RefundUnion = OneOf<RefundPending, RefundAuthorized>;

--- a/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlow.cs
+++ b/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlow.cs
@@ -39,13 +39,15 @@ namespace TrueLayer.Payments.Model.AuthorizationFlow
     /// <param name="UserAccountSelection">Can your UI render a user account selection screen?
     /// If the user has previously consented to saving their bank account details with TrueLayer, they can choose from their saved accounts to speed up following payments.
     /// This field states whether your UI can render a selection screen for these saved accounts. If you omit this, the user isn't presented with this option.</param>
+    /// <param name="Retry">The retry opt-in option for the authorization flow</param>
     public record StartAuthorizationFlowRequest(
         ProviderSelectionUnion? ProviderSelection = null,
         SchemeSelectionUnion? SchemeSelection = null,
         Redirect? Redirect = null,
         Form? Form = null,
         Consent? Consent = null,
-        UserAccountSelection? UserAccountSelection = null);
+        UserAccountSelection? UserAccountSelection = null,
+        Retry.BaseRetry? Retry = null);
 
     /// <summary>
     /// Contains the information regarding the configuration of the authorization flow.

--- a/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlow.cs
+++ b/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlow.cs
@@ -47,5 +47,22 @@ namespace TrueLayer.Payments.Model.AuthorizationFlow
         Consent? Consent = null,
         UserAccountSelection? UserAccountSelection = null);
 
-
+    /// <summary>
+    /// Contains the information regarding the configuration of the authorization flow.
+    /// </summary>
+    /// <param name="ProviderSelection">The configured provider selection option</param>
+    /// <param name="SchemeSelection">The configured scheme selection option</param>
+    /// <param name="Form">The configured form option</param>
+    /// <param name="Redirect">The configured redirect option</param>
+    /// <param name="Consent">The configured consent option</param>
+    /// <param name="UserAccountSelection">The configured user account selection option</param>
+    /// <param name="Retry">The configured retry option</param>
+    public record Configuration(
+        ProviderSelectionUnion? ProviderSelection = null,
+        SchemeSelectionUnion? SchemeSelection = null,
+        Redirect? Redirect = null,
+        Form? Form = null,
+        Consent? Consent = null,
+        UserAccountSelection? UserAccountSelection = null,
+        Retry.BaseRetry? Retry = null);
 }

--- a/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlowAction.cs
+++ b/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlowAction.cs
@@ -25,7 +25,7 @@ public record Actions(AuthorizationFlowActionUnion Next);
 /// Contains information regarding the nature and the state of the authorization flow.
 /// </summary>
 /// <param name="Actions">Contains the next action to be taken in the authorization flow.</param>
-public record AuthorizationFlow(Actions Actions);
+public record AuthorizationFlow(Actions Actions, Configuration? Configuration);
 
 /// <summary>
 /// This static class contains the different types of actions that can be taken during the authorization flow.

--- a/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlowAction.cs
+++ b/src/TrueLayer/Payments/Model/AuthorizationFlow/AuthorizationFlowAction.cs
@@ -12,7 +12,8 @@ using AuthorizationFlowActionUnion = OneOf<
     Models.AuthorizationFlowAction.WaitForOutcome,
     Models.AuthorizationFlowAction.Form,
     AuthorizationFlowAction.Consent,
-    AuthorizationFlowAction.UserAccountSelection
+    AuthorizationFlowAction.UserAccountSelection,
+    AuthorizationFlowAction.Retry
 >;
 
 /// <summary>
@@ -69,4 +70,12 @@ public static class AuthorizationFlowAction
         Fee Fee);
 
     public record Fee(int AmountInMinor, string Currency);
+
+    [JsonDiscriminator("retry")]
+    public record Retry(string Type, List<RetryOption> RetryOptions) : IDiscriminated;
+
+    public enum RetryOption
+    {
+        Restart,
+    }
 }

--- a/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
@@ -62,17 +62,5 @@ namespace TrueLayer.Payments.Model
         /// <param name="FailureReason">The reason for failure</param>
         [JsonDiscriminator("failed")]
         public record Failed(string FailureStage, string FailureReason) : PaymentDetails;
-
-        /// <summary>
-        /// Represents a payment that failed to complete due to an error in the authorization flow
-        /// </summary>
-        /// <param name="FailureStage"></param>
-        /// <param name="FailureReason"></param>
-        [JsonDiscriminator("attempt_failed")]
-        public record AttemptFailed(string FailureStage, string FailureReason) : Failed(FailureStage, FailureReason)
-        {
-            public AuthorizationFlow.AuthorizationFlow? AuthorizationFlow { get; init; } = null;
-            public PaymentSource? PaymentSource { get; init; } = null;
-        }
     }
 }

--- a/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/CreatePaymentResponse.cs
@@ -52,7 +52,7 @@ namespace TrueLayer.Payments.Model
         [JsonDiscriminator("authorizing")]
         public record Authorizing : PaymentDetails
         {
-            public AuthorizationFlow.AuthorizationFlow AuthorizationFlow { get; init; } = null!;
+            public AuthorizationFlow.AuthorizationFlow? AuthorizationFlow { get; init; } = null;
         }
 
         /// <summary>
@@ -62,5 +62,17 @@ namespace TrueLayer.Payments.Model
         /// <param name="FailureReason">The reason for failure</param>
         [JsonDiscriminator("failed")]
         public record Failed(string FailureStage, string FailureReason) : PaymentDetails;
+
+        /// <summary>
+        /// Represents a payment that failed to complete due to an error in the authorization flow
+        /// </summary>
+        /// <param name="FailureStage"></param>
+        /// <param name="FailureReason"></param>
+        [JsonDiscriminator("attempt_failed")]
+        public record AttemptFailed(string FailureStage, string FailureReason) : Failed(FailureStage, FailureReason)
+        {
+            public AuthorizationFlow.AuthorizationFlow? AuthorizationFlow { get; init; } = null;
+            public PaymentSource? PaymentSource { get; init; } = null;
+        }
     }
 }

--- a/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
@@ -16,7 +16,7 @@ namespace TrueLayer.Payments.Model
         /// Base class containing common properties for all payment states
         /// </summary>
         /// <value></value>
-        public record PaymentDetails
+        public abstract record PaymentDetails
         {
             /// <summary>
             /// Gets the unique identifier of the payment
@@ -104,5 +104,26 @@ namespace TrueLayer.Payments.Model
         /// <returns></returns>
         [JsonDiscriminator("failed")]
         public record Failed(DateTime FailedAt, string FailureStage, string FailureReason) : PaymentDetails;
+
+
+        /// <summary>
+        /// Represents a payment that failed to complete due to an error in the authorization flow
+        /// </summary>
+        /// <param name="FailedAt">The date and time the payment failed</param>
+        /// <param name="FailureStage">The status the payment was in when it failed</param>
+        /// <param name="FailureReason">The reason for failure</param>
+        [JsonDiscriminator("attempt_failed")]
+        public record AttemptFailed(DateTime FailedAt, string FailureStage, string FailureReason) : Failed(FailedAt, FailureStage, FailureReason)
+        {
+            /// <summary>
+            /// Gets the details of the authorization flow used for the payment
+            /// </summary>
+            public AuthorizationFlow.AuthorizationFlow? AuthorizationFlow { get; init; } = null;
+
+            /// <summary>
+            /// Gets the details of the source of funds for the payment<
+            /// </summary>
+            public PaymentSource? PaymentSource { get; init; } = null;
+        }
     }
 }

--- a/src/TrueLayer/Payments/Model/PaymentMethod.cs
+++ b/src/TrueLayer/Payments/Model/PaymentMethod.cs
@@ -26,10 +26,12 @@ namespace TrueLayer.Payments.Model
             /// </summary>
             /// <param name="providerSelection">The options for selecting a provider for the payment</param>
             /// <param name="beneficiary">The details of the payment destination</param>
-            public BankTransfer(ProviderUnion providerSelection, BeneficiaryUnion beneficiary)
+            /// <param name="retry">The retry object flag for the payment</param>
+            public BankTransfer(ProviderUnion providerSelection, BeneficiaryUnion beneficiary, BaseRetry? retry = null)
             {
                 ProviderSelection = providerSelection.NotNull(nameof(providerSelection));
                 Beneficiary = beneficiary.NotNull(nameof(beneficiary));
+                Retry = retry;
             }
 
             /// <summary>
@@ -46,6 +48,11 @@ namespace TrueLayer.Payments.Model
             /// Gets or inits the beneficiary details
             /// </summary>
             public BeneficiaryUnion Beneficiary { get; init; }
+
+            /// <summary>
+            /// Gets or inits the retry flag object for the payment
+            /// </summary>
+            public BaseRetry? Retry { get; init; }
         }
 
         /// <summary>

--- a/src/TrueLayer/Payments/Model/Retry.cs
+++ b/src/TrueLayer/Payments/Model/Retry.cs
@@ -7,6 +7,8 @@ namespace TrueLayer.Payments.Model
     /// </summary>
     public static class Retry
     {
+        public record BaseRetry();
+
         /// <summary>
         /// Standard retry feature
         /// </summary>

--- a/src/TrueLayer/Payments/PaymentsApi.cs
+++ b/src/TrueLayer/Payments/PaymentsApi.cs
@@ -18,8 +18,7 @@ namespace TrueLayer.Payments
         CreatePaymentResponse.AuthorizationRequired,
         CreatePaymentResponse.Authorized,
         CreatePaymentResponse.Failed,
-        CreatePaymentResponse.Authorizing,
-        CreatePaymentResponse.AttemptFailed
+        CreatePaymentResponse.Authorizing
     >;
     using GetPaymentUnion = OneOf<
         GetPaymentResponse.AuthorizationRequired,
@@ -27,7 +26,8 @@ namespace TrueLayer.Payments
         GetPaymentResponse.Authorized,
         GetPaymentResponse.Executed,
         GetPaymentResponse.Settled,
-        GetPaymentResponse.Failed
+        GetPaymentResponse.Failed,
+        GetPaymentResponse.AttemptFailed
     >;
 
     using RefundUnion = OneOf<RefundPending, RefundAuthorized>;

--- a/src/TrueLayer/Payments/PaymentsApi.cs
+++ b/src/TrueLayer/Payments/PaymentsApi.cs
@@ -18,7 +18,8 @@ namespace TrueLayer.Payments
         CreatePaymentResponse.AuthorizationRequired,
         CreatePaymentResponse.Authorized,
         CreatePaymentResponse.Failed,
-        CreatePaymentResponse.Authorizing
+        CreatePaymentResponse.Authorizing,
+        CreatePaymentResponse.AttemptFailed
     >;
     using GetPaymentUnion = OneOf<
         GetPaymentResponse.AuthorizationRequired,

--- a/src/TrueLayer/Serialization/OneOfJsonConverter.cs
+++ b/src/TrueLayer/Serialization/OneOfJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using OneOf;
@@ -26,6 +27,11 @@ namespace TrueLayer.Serialization
             Utf8JsonReader readerClone = reader;
 
             var doc = JsonDocument.ParseValue(ref reader);
+
+            if (doc.RootElement.ValueKind == JsonValueKind.Object && !doc.RootElement.EnumerateObject().Any())
+            {
+                return default;
+            }
 
             if (doc.RootElement.TryGetProperty(_discriminatorFieldName, out var discriminator)
                 && (_descriptor.TypeFactories.TryGetValue(discriminator.GetString()!, out var typeFactory)))

--- a/test/TrueLayer.AcceptanceTests/MandatesTests.cs
+++ b/test/TrueLayer.AcceptanceTests/MandatesTests.cs
@@ -66,11 +66,11 @@ namespace TrueLayer.AcceptanceTests
         }
 
 
-        [Theory(Skip = "Flaky tests, need to be fixed")]
+        [Theory]
         [MemberData(nameof(CreateTestSweepingUserSelectedMandateRequests))]
-        [MemberData(nameof(CreateTestCommercialUserSelectedMandateRequests))]
+        [MemberData(nameof(CreateTestCommercialUserSelectedMandateRequests), Skip = "It returns forbidden. Need to investigate.")]
         [MemberData(nameof(CreateTestSweepingPreselectedMandateRequests))]
-        [MemberData(nameof(CreateTestCommercialPreselectedMandateRequests))]
+        [MemberData(nameof(CreateTestCommercialPreselectedMandateRequests), Skip = "It returns forbidden. Need to investigate.")]
         public async Task Can_get_mandate(CreateMandateRequest mandateRequest)
         {
             // Arrange

--- a/test/TrueLayer.AcceptanceTests/PaymentTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentTests.cs
@@ -259,7 +259,8 @@ public partial class PaymentTests : IClassFixture<ApiTestFixture>
         string currency = Currencies.GBP,
         RelatedProducts? relatedProducts = null,
         StartAuthorizationFlowRequest? authorizationFlow = null,
-        BeneficiaryUnion? beneficiary = null)
+        BeneficiaryUnion? beneficiary = null,
+        Retry.BaseRetry? retry = null)
         => new CreatePaymentRequest(
             100,
             currency,
@@ -269,8 +270,8 @@ public partial class PaymentTests : IClassFixture<ApiTestFixture>
                     "TrueLayer",
                     "truelayer-dotnet",
                     accountIdentifier
-                )),
-
+                ),
+                retry),
             new PaymentUserRequest(
                 name: "Jane Doe",
                 email: "jane.doe@example.com",
@@ -450,6 +451,29 @@ public partial class PaymentTests : IClassFixture<ApiTestFixture>
                 },
                 new AccountIdentifier.Bban("IT60X0542811101000000123456"),
                 Currencies.NOK),
+        };
+        // Create a payment with retry
+        yield return new object[]
+        {
+            CreateTestPaymentRequest(new Provider.UserSelected
+                {
+                    Filter = providerFilterMockGbRedirect,
+                    SchemeSelection = new SchemeSelection.InstantOnly() { AllowRemitterFee = true },
+                },
+                sortCodeAccountNumber,
+                retry: new Retry.BaseRetry()),
+        };
+        yield return new object[]
+        {
+            CreateTestPaymentRequest(
+                new Provider.Preselected(
+                    "mock-payments-gb-redirect",
+                    schemeSelection: new SchemeSelection.InstantPreferred() { AllowRemitterFee = false })
+                {
+                    Remitter = remitterSortAccountNumber,
+                },
+                sortCodeAccountNumber,
+                retry: new Retry.BaseRetry()),
         };
     }
 

--- a/test/TrueLayer.AcceptanceTests/TestUtils.cs
+++ b/test/TrueLayer.AcceptanceTests/TestUtils.cs
@@ -32,7 +32,7 @@ public enum HeadlessResourceAction
     Invalid,
     Execute,
     Authorize,
-    RejectAuthorization
+    RejectAuthorisation
 }
 
 public enum HeadlessResource {
@@ -63,7 +63,7 @@ public static class TestUtils
         var authResponseString = await authResponse.Content.ReadAsStringAsync();
         var authResponseUri = new Uri(authResponseString);
 
-        String query = authorization.Resource == HeadlessResource.Mandates
+        var query = authorization.Resource == HeadlessResource.Mandates
             ? authResponseUri.Query.Replace("mandate-", "")
             : authResponseUri.Query;
 

--- a/test/TrueLayer.Tests/Serialization/OneOfJsonConverterTests.cs
+++ b/test/TrueLayer.Tests/Serialization/OneOfJsonConverterTests.cs
@@ -62,6 +62,21 @@ namespace TrueLayer.Tests.Serialization
         }
 
         [Fact]
+        public void Can_fallback_to_status_discriminator_when_type_discriminator_does_not_match()
+        {
+            string json = @"{
+                    ""type"": ""NotMatched"",
+                    ""status"": ""Bar"",
+                    ""BarProp"": 10
+                }
+            ";
+
+            var oneOf = JsonSerializer.Deserialize<OneOf<Foo, Bar>>(json, _options);
+            oneOf.AsT1.BarProp.ShouldBe(10);
+            oneOf.Value.ShouldBeOfType<Bar>();
+        }
+
+        [Fact]
         public void Can_read_from_status_discriminator_Refund()
         {
             string json = @"{
@@ -110,6 +125,17 @@ namespace TrueLayer.Tests.Serialization
 
             var oneOf = JsonSerializer.Deserialize<OneOf<Foo, Other>>(json, _options);
             oneOf.Value.ShouldBeOfType<Other>();
+        }
+
+        [Fact]
+        public void Returns_default_value_for_empty_objects()
+        {
+            string json = @"{
+                }
+            ";
+
+            var oneOf = JsonSerializer.Deserialize<OneOf<Foo, Other>>(json, _options);
+            oneOf.Value.ShouldBe(default);
         }
 
         [Fact]


### PR DESCRIPTION
This PR implements the support to the `Retry` option for the `CreatePaymentRequest` and the new `attempt_failed` payment status. 
More details can be found [here](https://docs.truelayer.com/docs/web-sdk#payment-retries-for-web-sdk). 