### PR TITLE
fix(acl-176): fix releaseChannel parameter in SearchPaymentsProvidersRequest

### DIFF
--- a/src/TrueLayer/PaymentsProviders/Model/SearchPaymentsProvidersRequest.cs
+++ b/src/TrueLayer/PaymentsProviders/Model/SearchPaymentsProvidersRequest.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
-using TrueLayer.Models;
 
 namespace TrueLayer.PaymentsProviders.Model;
 
 public record SearchPaymentsProvidersRequest(AuthorizationFlow AuthorizationFlow,
     List<string>? Countries = null,
     List<string>? Currencies = null,
-    List<string>? ReleaseChannels = null,
+    string? ReleaseChannel = null,
     List<string>? CustomerSegments = null,
     Capabilities? Capabilities = null);

--- a/test/TrueLayer.AcceptanceTests/PaymentsProvidersTests.cs
+++ b/test/TrueLayer.AcceptanceTests/PaymentsProvidersTests.cs
@@ -60,11 +60,20 @@ namespace TrueLayer.AcceptanceTests
             response.Data.Capabilities.Mandates?.VrpSweeping?.ReleaseChannel.ShouldNotBeNullOrWhiteSpace();
         }
 
-        [Fact]
-        public async Task Can_search_payments_providers()
+        [Theory]
+        [MemberData(nameof(SearchPaymentProvidersData))]
+        public async Task Can_search_payments_providers(
+            List<string>? countries = null,
+            List<string>? currencies = null,
+            string? releaseChannel = null,
+            List<string>? customerSegments = null)
         {
             var searchRequest = new SearchPaymentsProvidersRequest(
-                new AuthorizationFlow(new AuthorizationFlowConfiguration())
+                new AuthorizationFlow(new AuthorizationFlowConfiguration()),
+                countries,
+                currencies,
+                releaseChannel,
+                customerSegments
             );
 
             var response = await _fixture.Client.PaymentsProviders.SearchPaymentsProviders(searchRequest);
@@ -77,9 +86,26 @@ namespace TrueLayer.AcceptanceTests
                 pp.Id.ShouldNotBeEmpty();
                 pp.DisplayName.ShouldNotBeNullOrWhiteSpace();
                 pp.CountryCode.ShouldNotBeNullOrWhiteSpace();
+                pp.CountryCode.ShouldNotBeNullOrWhiteSpace();
+                if (countries != null && countries.Any())
+                {
+                    countries.ShouldContain(pp.CountryCode);
+                }
                 pp.Capabilities.Mandates?.VrpSweeping.ShouldNotBeNull();
                 pp.Capabilities.Mandates?.VrpSweeping?.ReleaseChannel.ShouldNotBeNullOrWhiteSpace();
             });
+        }
+
+        public static IEnumerable<object?[]> SearchPaymentProvidersData()
+        {
+            yield return new object?[] { null, null, null, null };
+            yield return new object?[] { new List<string> { "GB" }, null, null, null };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, null, null };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, "general_availability", null };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, "private_beta", null };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, "public_beta", null };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, "general_availability", new List<string> { "retail" } };
+            yield return new object?[] { new List<string> { "GB" }, new List<string> { "GBP" }, "general_availability", new List<string> { "retail", "corporate" } };
         }
     }
 }


### PR DESCRIPTION
#199 introduced the support to the search providers endpoint but unfortunately the `SeachPaymentsProvidersRequest` had a wrong `ReleaseChannels` parameter. This PR is fixing it (see [doc](https://docs.truelayer.com/reference/search-payment-providers)).