### PR TITLE
Set LangVersion to 10.0 as latest is discouraged

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,16 +1,12 @@
 <Project>
     <PropertyGroup>
-        <LangVersion>latest</LangVersion>
-        <!-- Enable nullable and treat their warnings as errors -->
-        <!--<Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable;</WarningsAsErrors>-->
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
     <PropertyGroup>
-        <Authors>@benfoster</Authors>
-        <Company>o9d</Company>
-        <PackageProjectUrl>https://github.com/truelayer/truelayer-sdk-net</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/truelayer/truelayer-sdk-net.git</RepositoryUrl>
+        <Authors>TrueLayer</Authors>
+        <Company>TrueLayer</Company>
+        <PackageProjectUrl>https://github.com/truelayer/truelayer-dotnet</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/truelayer/truelayer-dotnet.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>
     <PropertyGroup Label="MinVer">

--- a/src/TrueLayer/TrueLayer.csproj
+++ b/src/TrueLayer/TrueLayer.csproj
@@ -6,7 +6,7 @@
         <PackageId>TrueLayer.Client</PackageId>
         <Description>.NET client for the TrueLayer API</Description>
         <PackageIcon>icon.png</PackageIcon>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Authors>TrueLayer</Authors>
         <Company>TrueLayer</Company>
         <RepositoryUrl>https://github.com/TrueLayer/truelayer-dotnet</RepositoryUrl>

--- a/test/TrueLayer.Tests/TrueLayer.Tests.csproj
+++ b/test/TrueLayer.Tests/TrueLayer.Tests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net9.0;net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable;</WarningsAsErrors>
     </PropertyGroup>

--- a/test/TrueLayer.Tests/TrueLayerServiceCollectionExtensionsTests.cs
+++ b/test/TrueLayer.Tests/TrueLayerServiceCollectionExtensionsTests.cs
@@ -20,12 +20,13 @@ c3VMlcFZw7Y0iLjxAQFPvHqJ9vn3xWp+d3JREU1vQJ9daXswwbcoer88o1oVFmFf
 WS1/11+TH1x/lgKckAws6sAzJLPtCUZLV4IZTb6ENg==
 -----END EC PRIVATE KEY-----";
             var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection([
+                .AddInMemoryCollection(new[]
+                {
                     new KeyValuePair<string, string?>("TrueLayer:ClientId", "client_id"),
                     new KeyValuePair<string, string?>("TrueLayer:ClientSecret", "secret"),
                     new KeyValuePair<string, string?>("TrueLayer:Payments:SigningKey:KeyId", Guid.NewGuid().ToString()),
                     new KeyValuePair<string, string?>("TrueLayer:Payments:SigningKey:PrivateKey", privateKey)
-                ])
+                })
                 .Build();
             var services = new ServiceCollection()
                 .AddTrueLayer(configuration)


### PR DESCRIPTION
>  Warning
> 
> Setting the LangVersion element to latest is discouraged. The latest setting means the installed compiler uses its latest version. That can change from machine to machine, making builds unreliable. In addition, it enables language features that may require runtime or library features not included in the current SDK.