### PR TITLE
Fix incorrect field nullability constraint

### DIFF
--- a/src/TrueLayer/Common/Address.cs
+++ b/src/TrueLayer/Common/Address.cs
@@ -7,18 +7,19 @@ public record Address
     /// </summary>
     public Address(
         string city,
-        string state,
+        string? state,
         string zip,
         string countryCode,
         string addressLine1,
         string? addressLine2 = null)
     {
         AddressLine1 = addressLine1.NotNullOrWhiteSpace(nameof(addressLine1));
-        AddressLine2 = addressLine2.NotEmptyOrWhiteSpace(nameof(addressLine2));
         City = city.NotNullOrWhiteSpace(nameof(city));
-        State = state.NotNullOrWhiteSpace(nameof(state));
         Zip = zip.NotNullOrWhiteSpace(nameof(zip));
         CountryCode = countryCode.NotNullOrWhiteSpace(nameof(countryCode));
+
+        AddressLine2 = addressLine2.NotEmptyOrWhiteSpace(nameof(addressLine2));
+        State = state.NotEmptyOrWhiteSpace(nameof(state));
     }
 
     /// <summary>
@@ -39,7 +40,7 @@ public record Address
     /// <summary>
     /// Gets the name of the country / stat.
     /// </summary>
-    public string State { get; }
+    public string? State { get; }
 
     /// <summary>
     /// Gets the zip code or postal code

--- a/test/TrueLayer.Tests/Common/AddressTests.cs
+++ b/test/TrueLayer.Tests/Common/AddressTests.cs
@@ -18,7 +18,7 @@ public class AddressTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void New_address_throws_if_city_null_or_empty(string city)
+    public void New_address_throws_if_city_is_empty_or_whitespace(string city)
     {
         Assert.Throws<ArgumentException>("city",
             () => new Address(city, "state", "zip", "country Code", "addressLine1"));
@@ -27,16 +27,21 @@ public class AddressTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void New_address_throws_if_state_null_or_empty(string state)
+    public void New_address_throws_if_state_is_empty_or_whitespace(string state)
     {
         Assert.Throws<ArgumentException>("state",
             () => new Address("city", state, "zip", "country Code", "addressLine1"));
     }
 
+    [Fact]
+    public void New_address_is_created_successfully_if_state_is_null() =>
+        // ReSharper disable once ObjectCreationAsStatement
+        new Address("city", state: null, "zip", "countryCode", "addressLine1", "addressLine2");
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void New_address_throws_if_zip_null_or_empty(string zip)
+    public void New_address_throws_if_zip_is_empty_or_whitespace(string zip)
     {
         Assert.Throws<ArgumentException>("zip",
             () => new Address("city", "state", zip, "country Code", "addressLine1"));
@@ -45,7 +50,7 @@ public class AddressTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void New_address_throws_if_country_code_null_or_empty(string countryCode)
+    public void New_address_throws_if_country_code_is_empty_or_whitespace(string countryCode)
     {
         Assert.Throws<ArgumentException>("countryCode",
             () => new Address("city", "state", "zip", countryCode, "addressLine1"));
@@ -54,9 +59,14 @@ public class AddressTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    public void New_address_throws_if_address_line_2_null_or_empty(string addressLine2)
+    public void New_address_throws_if_address_line_2_is_empty_or_whitespace(string addressLine2)
     {
         Assert.Throws<ArgumentException>("addressLine2",
             () => new Address("city", "state", "zip", "countryCode", "addressLine1", addressLine2));
     }
+
+    [Fact]
+    public void New_address_is_created_successfully_if_address_line_2_is_null() =>
+        // ReSharper disable once ObjectCreationAsStatement
+        new Address("city", "state", "zip", "countryCode", "addressLine1", addressLine2: null);
 }


### PR DESCRIPTION
The user.address.state field is not required according to the [public doc](https://docs.truelayer.com/reference/create-payment).
