### PR TITLE
Add support for SubMerchants in CreatePaymentRequest and related tests

### DIFF
--- a/src/TrueLayer/Payments/Model/CreatePaymentRequest.cs
+++ b/src/TrueLayer/Payments/Model/CreatePaymentRequest.cs
@@ -24,6 +24,7 @@ namespace TrueLayer.Payments.Model
         /// If provided, the start authorization flow endpoint does not need to be called</param>
         /// <param name="metadata">Add to the payment a list of custom key-value pairs as metadata</param>
         /// <param name="riskAssessment">The risk assessment and the payment_creditable webhook configuration.</param>
+        /// <param name="subMerchants">Sub-merchant information for marketplace and platform payments.</param>
         public CreatePaymentRequest(
             long amountInMinor,
             string currency,
@@ -32,7 +33,8 @@ namespace TrueLayer.Payments.Model
             RelatedProducts? relatedProducts = null,
             StartAuthorizationFlowRequest? authorizationFlow = null,
             Dictionary<string, string>? metadata = null,
-            RiskAssessment? riskAssessment = null)
+            RiskAssessment? riskAssessment = null,
+            SubMerchants? subMerchants = null)
         {
             AmountInMinor = amountInMinor.GreaterThan(0, nameof(amountInMinor));
             Currency = currency.NotNullOrWhiteSpace(nameof(currency));
@@ -42,6 +44,7 @@ namespace TrueLayer.Payments.Model
             AuthorizationFlow = authorizationFlow;
             Metadata = metadata;
             RiskAssessment = riskAssessment;
+            SubMerchants = subMerchants;
         }
 
         /// <summary>
@@ -84,5 +87,10 @@ namespace TrueLayer.Payments.Model
         /// Gets the risk assessment configuration
         /// </summary>
         public RiskAssessment? RiskAssessment { get; }
+
+        /// <summary>
+        /// Gets the sub-merchant information for marketplace and platform payments
+        /// </summary>
+        public SubMerchants? SubMerchants { get; }
     }
 }

--- a/src/TrueLayer/Payments/Model/SubMerchants.cs
+++ b/src/TrueLayer/Payments/Model/SubMerchants.cs
@@ -1,0 +1,43 @@
+using TrueLayer.Serialization;
+
+namespace TrueLayer.Payments.Model
+{
+    /// <summary>
+    /// Represents sub-merchant information for marketplace and platform payments
+    /// </summary>
+    public record SubMerchants
+    {
+        /// <summary>
+        /// Creates a new <see cref="SubMerchants"/> instance
+        /// </summary>
+        /// <param name="ultimateCounterparty">The ultimate counterparty information</param>
+        public SubMerchants(UltimateCounterparty? ultimateCounterparty = null)
+        {
+            UltimateCounterparty = ultimateCounterparty;
+        }
+
+        /// <summary>
+        /// Gets the ultimate counterparty information
+        /// </summary>
+        public UltimateCounterparty? UltimateCounterparty { get; }
+    }
+
+    /// <summary>
+    /// Represents the ultimate counterparty in a payment transaction
+    /// </summary>
+    [JsonDiscriminator("business_division")]
+    public record UltimateCounterparty : IDiscriminated
+    {
+        /// <summary>
+        /// Creates a new <see cref="UltimateCounterparty"/> instance with business division type
+        /// </summary>
+        public UltimateCounterparty()
+        {
+        }
+
+        /// <summary>
+        /// Gets the type of ultimate counterparty
+        /// </summary>
+        public string Type => "business_division";
+    }
+}

--- a/test/TrueLayer.AcceptanceTests/RequestBuilders.cs
+++ b/test/TrueLayer.AcceptanceTests/RequestBuilders.cs
@@ -36,4 +36,22 @@ public static class RequestBuilders
             mandateRequest.User,
             setRelatedProducts ? new RelatedProducts(new SignupPlus()) : null);
 
+    public static CreatePaymentRequest CreateTestPaymentRequestWithSubMerchants(
+        string merchantAccountId,
+        long amountInMinor = 30000,
+        string currency = Currencies.GBP)
+        => new(
+            amountInMinor,
+            currency,
+            new PaymentMethod.BankTransfer(
+                new Provider.Preselected("mock-payments-gb-redirect"),
+                new Beneficiary.MerchantAccount(merchantAccountId)),
+            new PaymentUserRequest(
+                id: "f9b48c9d-176b-46dd-b2da-fe1a2b77350c",
+                name: "John Test",
+                email: "john.test@example.com",
+                phone: "+44123456789"),
+            metadata: new Dictionary<string, string> { { "test-key", "test-value" } },
+            subMerchants: new SubMerchants(new UltimateCounterparty()));
+
 }

--- a/test/TrueLayer.Tests/Payments/CreatePaymentRequestTests.cs
+++ b/test/TrueLayer.Tests/Payments/CreatePaymentRequestTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using TrueLayer.Common;
+using TrueLayer.Payments.Model;
+using Xunit;
+using static TrueLayer.Payments.Model.Beneficiary;
+using static TrueLayer.Payments.Model.PaymentMethod;
+using static TrueLayer.Payments.Model.Provider;
+using static TrueLayer.Payments.Model.AccountIdentifier;
+
+namespace TrueLayer.Tests.Payments
+{
+    public class CreatePaymentRequestTests
+    {
+        private readonly BankTransfer _validPaymentMethod;
+        private const long ValidAmount = 10000;
+        private const string ValidCurrency = "GBP";
+
+        public CreatePaymentRequestTests()
+        {
+            var beneficiary = new MerchantAccount("merchant-account-id");
+            var provider = new UserSelected();
+            _validPaymentMethod = new BankTransfer(provider, beneficiary);
+        }
+
+        [Fact]
+        public void CreatePaymentRequest_Can_Be_Created_With_Minimum_Required_Fields()
+        {
+            // Act
+            var request = new CreatePaymentRequest(ValidAmount, ValidCurrency, _validPaymentMethod);
+
+            // Assert
+            request.AmountInMinor.Should().Be(ValidAmount);
+            request.Currency.Should().Be(ValidCurrency);
+            request.PaymentMethod.Should().NotBeNull();
+            request.PaymentMethod.AsT0.Should().BeOfType<BankTransfer>();
+            request.User.Should().BeNull();
+            request.RelatedProducts.Should().BeNull();
+            request.AuthorizationFlow.Should().BeNull();
+            request.Metadata.Should().BeNull();
+            request.RiskAssessment.Should().BeNull();
+            request.SubMerchants.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreatePaymentRequest_Can_Be_Created_With_SubMerchants()
+        {
+            // Arrange
+            var ultimateCounterparty = new UltimateCounterparty();
+            var subMerchants = new SubMerchants(ultimateCounterparty);
+
+            // Act
+            var request = new CreatePaymentRequest(
+                ValidAmount, 
+                ValidCurrency, 
+                _validPaymentMethod,
+                subMerchants: subMerchants);
+
+            // Assert
+            request.SubMerchants.Should().Be(subMerchants);
+            request.SubMerchants!.UltimateCounterparty.Should().Be(ultimateCounterparty);
+        }
+
+        [Fact]
+        public void CreatePaymentRequest_Can_Be_Created_With_All_Optional_Fields()
+        {
+            // Arrange
+            var user = new PaymentUserRequest(
+                "user-id", 
+                "John Doe", 
+                "john@example.com", 
+                "+44123456789",
+                new DateTime(1990, 1, 1),
+                new Address("London", "London", "EC1A 1BB", "GB", "123 Test St"));
+            
+            var ultimateCounterparty = new UltimateCounterparty();
+            var subMerchants = new SubMerchants(ultimateCounterparty);
+            var metadata = new Dictionary<string, string> { ["key"] = "value" };
+
+            // Act
+            var request = new CreatePaymentRequest(
+                ValidAmount,
+                ValidCurrency,
+                _validPaymentMethod,
+                user,
+                relatedProducts: null,
+                authorizationFlow: null,
+                metadata,
+                riskAssessment: null,
+                subMerchants);
+
+            // Assert
+            request.AmountInMinor.Should().Be(ValidAmount);
+            request.Currency.Should().Be(ValidCurrency);
+            request.PaymentMethod.Should().NotBeNull();
+            request.PaymentMethod.AsT0.Should().BeOfType<BankTransfer>();
+            request.User.Should().Be(user);
+            request.Metadata.Should().BeEquivalentTo(metadata);
+            request.SubMerchants.Should().Be(subMerchants);
+            request.SubMerchants!.UltimateCounterparty.Should().Be(ultimateCounterparty);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        public void CreatePaymentRequest_Throws_If_Amount_Is_Zero_Or_Negative(long invalidAmount)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>("amountInMinor", () =>
+                new CreatePaymentRequest(invalidAmount, ValidCurrency, _validPaymentMethod));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void CreatePaymentRequest_Throws_If_Currency_Is_Null_Or_Whitespace(string? invalidCurrency)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>("currency", () =>
+                new CreatePaymentRequest(ValidAmount, invalidCurrency!, _validPaymentMethod));
+        }
+
+        // Note: PaymentMethod cannot be null since it's a OneOf union type
+        // This test would not compile if we tried to pass null
+    }
+}

--- a/test/TrueLayer.Tests/Payments/Model/SubMerchantsTests.cs
+++ b/test/TrueLayer.Tests/Payments/Model/SubMerchantsTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using TrueLayer.Payments.Model;
+using Xunit;
+
+namespace TrueLayer.Tests.Payments.Model
+{
+    public class SubMerchantsTests
+    {
+        [Fact]
+        public void SubMerchants_Can_Be_Created_With_Null_UltimateCounterparty()
+        {
+            // Act
+            var subMerchants = new SubMerchants();
+
+            // Assert
+            subMerchants.UltimateCounterparty.Should().BeNull();
+        }
+
+        [Fact]
+        public void SubMerchants_Can_Be_Created_With_UltimateCounterparty()
+        {
+            // Arrange
+            var ultimateCounterparty = new UltimateCounterparty();
+
+            // Act
+            var subMerchants = new SubMerchants(ultimateCounterparty);
+
+            // Assert
+            subMerchants.UltimateCounterparty.Should().Be(ultimateCounterparty);
+        }
+
+        [Fact]
+        public void UltimateCounterparty_Has_Correct_Type()
+        {
+            // Act
+            var ultimateCounterparty = new UltimateCounterparty();
+
+            // Assert
+            ultimateCounterparty.Type.Should().Be("business_division");
+        }
+
+        [Fact]
+        public void UltimateCounterparty_Can_Be_Created_Successfully()
+        {
+            // Act
+            var ultimateCounterparty = new UltimateCounterparty();
+
+            // Assert
+            ultimateCounterparty.Should().NotBeNull();
+            ultimateCounterparty.Type.Should().Be("business_division");
+        }
+    }
+}


### PR DESCRIPTION
Introduce SubMerchants and UltimateCounterparty models to enhance payment requests for marketplace and platform payments. Update CreatePaymentRequest to include sub-merchant information and implement tests to validate the new functionality.