### PR TITLE
[ACL-291] Add support for sub_merchant objects in Payments and Payouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,7 @@ $RECYCLE.BIN/
 !.vscode/extensions.json
 
 appsettings.local*.json
+
+# Claude Code configuration
+CLAUDE.local.md
+.claude

--- a/src/TrueLayer/Common/UltimateCounterparty.cs
+++ b/src/TrueLayer/Common/UltimateCounterparty.cs
@@ -1,0 +1,95 @@
+using TrueLayer.Serialization;
+
+namespace TrueLayer.Common
+{
+    /// <summary>
+    /// Represents the ultimate counterparty details for sub-merchants
+    /// </summary>
+    public abstract record UltimateCounterparty
+    {
+        /// <summary>
+        /// Gets the type of the ultimate counterparty
+        /// </summary>
+        public abstract string Type { get; }
+    }
+
+    /// <summary>
+    /// Represents business client details for the ultimate counterparty
+    /// </summary>
+    [JsonDiscriminator("business_client")]
+    public record UltimateCounterpartyBusinessClient : UltimateCounterparty
+    {
+        /// <summary>
+        /// Creates a new <see cref="UltimateCounterpartyBusinessClient"/>
+        /// </summary>
+        /// <param name="commercialName">The commercial name of the business</param>
+        /// <param name="mcc">The merchant category code of the business</param>
+        /// <param name="address">The address of the business (required if registration_number is not provided)</param>
+        /// <param name="registrationNumber">The registration number of the business (required if address is not provided)</param>
+        public UltimateCounterpartyBusinessClient(
+            string commercialName,
+            string? mcc = null,
+            Address? address = null,
+            string? registrationNumber = null)
+        {
+            CommercialName = commercialName.NotNullOrWhiteSpace(nameof(commercialName));
+            Mcc = mcc;
+            Address = address;
+            RegistrationNumber = registrationNumber;
+        }
+
+        /// <inheritdoc />
+        public override string Type => "business_client";
+
+        /// <summary>
+        /// Gets the commercial name of the business
+        /// </summary>
+        public string CommercialName { get; }
+
+        /// <summary>
+        /// Gets the merchant category code of the business
+        /// </summary>
+        public string? Mcc { get; }
+
+        /// <summary>
+        /// Gets the address of the business
+        /// </summary>
+        public Address? Address { get; }
+
+        /// <summary>
+        /// Gets the registration number of the business
+        /// </summary>
+        public string? RegistrationNumber { get; }
+    }
+
+    /// <summary>
+    /// Represents business division details for the ultimate counterparty
+    /// </summary>
+    [JsonDiscriminator("business_division")]
+    public record UltimateCounterpartyBusinessDivision : UltimateCounterparty
+    {
+        /// <summary>
+        /// Creates a new <see cref="UltimateCounterpartyBusinessDivision"/>
+        /// </summary>
+        /// <param name="id">The identifier of the business division</param>
+        /// <param name="name">The name of the business division</param>
+        public UltimateCounterpartyBusinessDivision(string id, string name)
+        {
+            Id = id.NotNullOrWhiteSpace(nameof(id));
+            Name = name.NotNullOrWhiteSpace(nameof(name));
+        }
+
+        /// <inheritdoc />
+        public override string Type => "business_division";
+
+        /// <summary>
+        /// Gets the identifier of the business division
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Gets the name of the business division
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/TrueLayer/Payments/Model/CreatePaymentRequest.cs
+++ b/src/TrueLayer/Payments/Model/CreatePaymentRequest.cs
@@ -24,6 +24,7 @@ namespace TrueLayer.Payments.Model
         /// If provided, the start authorization flow endpoint does not need to be called</param>
         /// <param name="metadata">Add to the payment a list of custom key-value pairs as metadata</param>
         /// <param name="riskAssessment">The risk assessment and the payment_creditable webhook configuration.</param>
+        /// <param name="subMerchants">The details related to any applicable sub-merchants</param>
         public CreatePaymentRequest(
             long amountInMinor,
             string currency,
@@ -32,7 +33,8 @@ namespace TrueLayer.Payments.Model
             RelatedProducts? relatedProducts = null,
             StartAuthorizationFlowRequest? authorizationFlow = null,
             Dictionary<string, string>? metadata = null,
-            RiskAssessment? riskAssessment = null)
+            RiskAssessment? riskAssessment = null,
+            PaymentSubMerchants? subMerchants = null)
         {
             AmountInMinor = amountInMinor.GreaterThan(0, nameof(amountInMinor));
             Currency = currency.NotNullOrWhiteSpace(nameof(currency));
@@ -42,6 +44,7 @@ namespace TrueLayer.Payments.Model
             AuthorizationFlow = authorizationFlow;
             Metadata = metadata;
             RiskAssessment = riskAssessment;
+            SubMerchants = subMerchants;
         }
 
         /// <summary>
@@ -84,5 +87,10 @@ namespace TrueLayer.Payments.Model
         /// Gets the risk assessment configuration
         /// </summary>
         public RiskAssessment? RiskAssessment { get; }
+
+        /// <summary>
+        /// Gets the sub-merchants details
+        /// </summary>
+        public PaymentSubMerchants? SubMerchants { get; }
     }
 }

--- a/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
+++ b/src/TrueLayer/Payments/Model/GetPaymentResponse.cs
@@ -60,6 +60,11 @@ namespace TrueLayer.Payments.Model
             /// Gets the metadata added to the payment.
             /// </summary>
             public Dictionary<string, string>? Metadata { get; init; } = null;
+
+            /// <summary>
+            /// Gets the sub-merchants details
+            /// </summary>
+            public PaymentSubMerchants? SubMerchants { get; init; } = null;
         }
 
         /// <summary>

--- a/src/TrueLayer/Payments/Model/SubMerchants.cs
+++ b/src/TrueLayer/Payments/Model/SubMerchants.cs
@@ -1,0 +1,27 @@
+using OneOf;
+using TrueLayer.Common;
+
+namespace TrueLayer.Payments.Model
+{
+    using PaymentUltimateCounterpartyUnion = OneOf<UltimateCounterpartyBusinessClient, UltimateCounterpartyBusinessDivision>;
+
+    /// <summary>
+    /// Represents sub-merchant details for payments
+    /// </summary>
+    public record PaymentSubMerchants
+    {
+        /// <summary>
+        /// Creates a new <see cref="PaymentSubMerchants"/>
+        /// </summary>
+        /// <param name="ultimateCounterparty">The ultimate counterparty details</param>
+        public PaymentSubMerchants(PaymentUltimateCounterpartyUnion ultimateCounterparty)
+        {
+            UltimateCounterparty = ultimateCounterparty;
+        }
+
+        /// <summary>
+        /// Gets the ultimate counterparty details
+        /// </summary>
+        public PaymentUltimateCounterpartyUnion UltimateCounterparty { get; }
+    }
+}

--- a/src/TrueLayer/Payouts/Model/CreatePayoutRequest.cs
+++ b/src/TrueLayer/Payouts/Model/CreatePayoutRequest.cs
@@ -21,13 +21,15 @@ namespace TrueLayer.Payouts.Model
         /// <param name="beneficiary">The payout beneficiary details</param>
         /// <param name="metadata">Metadata</param>
         /// <param name="schemeSelection">Metadata</param>
+        /// <param name="subMerchants">The details related to any applicable sub-merchants</param>
         public CreatePayoutRequest(
             string merchantAccountId,
             long amountInMinor,
             string currency,
             BeneficiaryUnion beneficiary,
             Dictionary<string, string>? metadata = null,
-            SchemeSelectionUnion? schemeSelection = null)
+            SchemeSelectionUnion? schemeSelection = null,
+            PayoutSubMerchants? subMerchants = null)
         {
             MerchantAccountId = merchantAccountId;
             AmountInMinor = amountInMinor.GreaterThan(0, nameof(amountInMinor));
@@ -35,6 +37,7 @@ namespace TrueLayer.Payouts.Model
             Beneficiary = beneficiary;
             Metadata = metadata;
             SchemeSelection = schemeSelection;
+            SubMerchants = subMerchants;
         }
 
         /// <summary>
@@ -67,5 +70,10 @@ namespace TrueLayer.Payouts.Model
         /// Gets the scheme selection
         /// </summary>
         public SchemeSelectionUnion? SchemeSelection { get; }
+
+        /// <summary>
+        /// Gets the sub-merchants details
+        /// </summary>
+        public PayoutSubMerchants? SubMerchants { get; }
     }
 }

--- a/src/TrueLayer/Payouts/Model/SubMerchants.cs
+++ b/src/TrueLayer/Payouts/Model/SubMerchants.cs
@@ -1,0 +1,24 @@
+using TrueLayer.Common;
+
+namespace TrueLayer.Payouts.Model
+{
+    /// <summary>
+    /// Represents sub-merchant details for payouts
+    /// </summary>
+    public record PayoutSubMerchants
+    {
+        /// <summary>
+        /// Creates a new <see cref="PayoutSubMerchants"/>
+        /// </summary>
+        /// <param name="ultimateCounterparty">The ultimate counterparty details (optional for payouts)</param>
+        public PayoutSubMerchants(UltimateCounterpartyBusinessClient? ultimateCounterparty = null)
+        {
+            UltimateCounterparty = ultimateCounterparty;
+        }
+
+        /// <summary>
+        /// Gets the ultimate counterparty details (only business_client is supported for payouts)
+        /// </summary>
+        public UltimateCounterpartyBusinessClient? UltimateCounterparty { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement sub_merchant objects for both Payments and Payouts according to OpenAPI v3 specifications
- Add support for UltimateCounterparty with business_client and business_division types for Payments
- Add support for UltimateCounterparty with business_client type only for Payouts
- Update request/response models to include SubMerchants properties

## Test plan
- [x] Build succeeds without errors
- [x] Unit tests pass (193/193)
- [ ] Integration tests with sub_merchant data
- [ ] Verify JSON serialization matches OpenAPI specs
- [ ] Test both business_client and business_division types for Payments
- [ ] Test business_client type for Payouts

🤖 Generated with [Claude Code](https://claude.ai/code)